### PR TITLE
Fix: displaying "0" instead of "12" in 12h format for (Datetime Picker) and (Time Picker)

### DIFF
--- a/resources/views/components/datetime-picker.blade.php
+++ b/resources/views/components/datetime-picker.blade.php
@@ -133,7 +133,7 @@ x-data="{
             let formatedHour = this.config.is12H ? Number(hour % 12) : hour
             const minutes    = Number(startTime % 60).toString().padStart(2, '0')
 
-            if (this.config.is12H && formatedHour === '00') { formatedHour = 12 }
+            if (this.config.is12H && formatedHour === 0) { formatedHour = 12 }
 
             const time = {
                 label: `${formatedHour}:${minutes}`,

--- a/resources/views/components/time-picker.blade.php
+++ b/resources/views/components/time-picker.blade.php
@@ -57,7 +57,7 @@
             const minutes    = Number(startTime % 60).toString().padStart(2, '0')
             const timePeriod = timePeriods[Math.floor(hour / 12)]
 
-            if (this.config.is12H && formatedHour === '00') { formatedHour = 12 }
+            if (this.config.is12H && formatedHour === 0) { formatedHour = 12 }
 
             let time = `${formatedHour}:${minutes}`
 


### PR DESCRIPTION
I noticed that "12" Hour is showing as 0 in the 12 hours time format.
I found that this issue was in an "if" statement.

**Screenshots Before:**
![image](https://user-images.githubusercontent.com/16672241/130580515-9299c7e0-bfa6-4e24-8fb6-2fd8b0fd73e3.png)
![image](https://user-images.githubusercontent.com/16672241/130580527-7c95ee63-b2ad-4792-8ac2-fc6b147d308f.png)

**Screenshots After:**
![image](https://user-images.githubusercontent.com/16672241/130580560-a6a015e1-f0fe-4fb1-a96b-435f24ea64c5.png)
![image](https://user-images.githubusercontent.com/16672241/130580568-d1bb1b3c-60f4-4ae1-a826-659ffa82ceff.png)

