### PR TITLE
White space normal on card title

### DIFF
--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -2,8 +2,8 @@
     @if ($header)
         {{ $header }}
     @elseif ($title || $action)
-        <div class="px-4 py-2.5 flex justify-between items-center border-b dark:border-0">
-            <h3 class="text-md font-medium text-secondary-700 dark:text-secondary-400">{{ $title }}</h3>
+        <div class="px-4 py-2.5 flex justify-between items-center border-b dark:border-0 ">
+            <h3 class="text-md font-medium text-secondary-700 dark:text-secondary-400 whitespace-normal">{{ $title }}</h3>
 
             @if ($action)
                 {{ $action }}


### PR DESCRIPTION
When the title is too long, this class help to have a title in 2 rows
![image](https://user-images.githubusercontent.com/497169/144398284-c87a0a8f-7879-4e7a-acfa-e0e8d0957856.png)
