### PR TITLE
fix: Select component keyboard navigation

### DIFF
--- a/ts/components/select.ts
+++ b/ts/components/select.ts
@@ -168,7 +168,11 @@ export default (options: InitOptions): Select => ({
 
     return textarea.value
   },
-  getFocusables () { return [...this.$el.querySelectorAll('li, input')] },
+  getFocusables () {
+    const focusables = this.$el.querySelectorAll('li, input')
+
+    return focusables.length > 0 ? [...focusables] : [...this.$root.querySelectorAll('li, input')]
+  },
   getFirstFocusable () { return this.getFocusables().shift() },
   getLastFocusable () { return this.getFocusables().pop() },
   getNextFocusable () { return this.getFocusables()[this.getNextFocusableIndex()] || this.getFirstFocusable() },

--- a/ts/components/select.ts
+++ b/ts/components/select.ts
@@ -169,9 +169,9 @@ export default (options: InitOptions): Select => ({
     return textarea.value
   },
   getFocusables () {
-    const focusables = this.$el.querySelectorAll('li, input')
+    const focusables = this.$el?.querySelectorAll('li, input') ?? []
 
-    return focusables.length > 0 ? [...focusables] : [...this.$root.querySelectorAll('li, input')]
+    return focusables.length > 0 ? [...focusables] : [...this.$root?.querySelectorAll('li, input')]
   },
   getFirstFocusable () { return this.getFocusables().shift() },
   getLastFocusable () { return this.getFocusables().pop() },


### PR DESCRIPTION
Keyboard navigation seems to be broken on the "Custom Options" version found in the docs. 

```javascript
// this always returns an empty array when using "custom options"
getFocusables () { return [...this.$el.querySelectorAll('li, input')] }, 
```

If no element is found using the code above we should try to find the focusable elements using the $root element

