### PR TITLE
fix: remove line breaks in textarea tags

### DIFF
--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -51,8 +51,7 @@
             ])->merge([
                 'autocomplete' => 'off',
                 'rows'         => 4
-            ]) }}>
-        </textarea>
+            ]) }}></textarea>
 
         @if ($suffix || $rightIcon || ($hasError && !$append))
             <div class="absolute inset-y-0 right-0 pr-2.5 flex items-center pointer-events-none


### PR DESCRIPTION
When merging the following PRs, an extra line break was introduced into the textarea tag.
#120

As a result, the textarea is now displayed with an extra space as shown below.
<img width="203" alt="スクリーンショット 2022-01-29 12 11 06" src="https://user-images.githubusercontent.com/16968828/151645146-110c2aa0-2391-41eb-9b27-662425ecf8b4.png">

This PR fixes this problem.