### PR TITLE
Allow select with no label

### DIFF
--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -9,13 +9,15 @@
         optionLabel: '{{ $optionLabel }}',
     })" class="relative" {{ $attributes->only('wire:key') }}>
     <div class="relative">
-        <x-dynamic-component
-            :component="WireUiComponent::resolve('label')"
-            class="mb-1"
-            :label="$label"
-            :has-error="$errors->has($name) ?? false"
-            x-on:click="togglePopover"
-        />
+        @if ($label)
+            <x-dynamic-component
+                :component="WireUiComponent::resolve('label')"
+                class="mb-1"
+                :label="$label"
+                :has-error="$errors->has($name) ?? false"
+                x-on:click="togglePopover"
+            />
+        @endif
 
         <x-dynamic-component
             :component="WireUiComponent::resolve('input')"


### PR DESCRIPTION
Sometimes, u need a select without a label. This PR will only show the select label if we provided the label attributes.