### PR TITLE
Fix render button on dialog

### DIFF
--- a/ts/dialog/actions.ts
+++ b/ts/dialog/actions.ts
@@ -75,6 +75,15 @@ export const parseActions = (options: ConfirmationOptions, componentId?: string)
       action.execute = parseAction(action, componentId)
     }
 
+    if (
+      actionName === 'accept'
+      && !action.color
+      && typeof options.icon === 'string'
+      && ['success', 'error', 'info', 'warning', 'question'].includes(options.icon)
+    ) {
+      action.color = iconsMap[options.icon] ?? options.icon
+    }
+
     if (actionName === 'accept' && !action.color) {
       action.color = 'primary'
     }

--- a/ts/dialog/actions.ts
+++ b/ts/dialog/actions.ts
@@ -67,20 +67,12 @@ export const parseActions = (options: ConfirmationOptions, componentId?: string)
     }, options.accept)
   }
 
-  return Object.assign({}, ...['accept', 'reject'].map(actionName => {
+  return Object.assign({}, ...['accept', 'reject', 'close'].map(actionName => {
     const action = Object.assign({}, options[actionName]) as ActionOptions
     action.label = getActionLabel(options, action, actionName)
 
     if (!action.execute) {
       action.execute = parseAction(action, componentId)
-    }
-
-    if (
-      actionName === 'accept'
-      && !action.color
-      && typeof options.icon === 'string'
-    ) {
-      action.color = iconsMap[options.icon] ?? options.icon
     }
 
     if (actionName === 'accept' && !action.color) {

--- a/ts/dialog/parses.ts
+++ b/ts/dialog/parses.ts
@@ -35,7 +35,11 @@ export const parseDialog: ParseDialog = (options, componentId?): Dialog => {
   if (
     typeof dialog.close === 'object'
     && !dialog.close.color
-    && typeof options.icon === 'string'
+    && (options.icon == 'success' ||
+        options.icon == 'error' ||
+        options.icon == 'info' ||
+        options.icon == 'warning' ||
+        options.icon == 'question')
   ) {
     dialog.close.color = iconsMap[options.icon] ?? options.icon
   }

--- a/ts/dialog/parses.ts
+++ b/ts/dialog/parses.ts
@@ -35,11 +35,8 @@ export const parseDialog: ParseDialog = (options, componentId?): Dialog => {
   if (
     typeof dialog.close === 'object'
     && !dialog.close.color
-    && (options.icon == 'success' ||
-        options.icon == 'error' ||
-        options.icon == 'info' ||
-        options.icon == 'warning' ||
-        options.icon == 'question')
+    && typeof options.icon === 'string'
+    && ['success', 'error', 'info', 'warning', 'question'].includes(options.icon)
   ) {
     dialog.close.color = iconsMap[options.icon] ?? options.icon
   }


### PR DESCRIPTION
This PR fix the button to be rendered on the dialog modal.

If you use one of this, it should be ok and its rendered.

```php
$this->dialog()->show([
    'title'       => 'Profile saved!',
    'description' => 'Your profile was successfull saved',
    'icon'        => 'error' // success, error, info, warning, question
]);
```

otherwise, when you trying to change to this, it will not rendered on the modal.

```php
$this->dialog()->show([
    'title'       => 'Profile saved!',
    'description' => 'Your profile was successfull saved',
    'icon'        => 'users'
]);
```