### PR TITLE
Fix array_merge() at optionsToJson() error

### DIFF
--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -74,7 +74,7 @@ class Select extends NativeSelect
                 ];
 
                 if ($this->optionValue) {
-                    $option = array_merge($rawOption, $option);
+                    $option = array_merge((array) $rawOption, $option);
                 }
 
                 if ($this->optionValue && $this->optionValue !== 'value') {


### PR DESCRIPTION
This PR will fix the error array_merge() issue when you use a collection into select component.

View :
```blade
<x-select
        label="Phone Type"
        placeholder="..."
        :options="$this->phoneTypes"
        option-label="name"
        option-value="id"
        wire:model.lazy="model"
    />
```

Component : 
```php
<?php

namespace App\Http\Livewire;

use App\Models\PhoneType;
use Livewire\Component;

class Welcome extends Component
{
    public function getPhoneTypesProperty()
    {
        return PhoneType::all();
    }

    public function render()
    {
        return view('livewire.welcome');
    }
}
```