### PR TITLE
Fix ucwords(), ctype_lower(), strlen() and explode() warnings

### DIFF
--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -4,7 +4,7 @@
     $defaultAttributes = [
         'wire:loading.attr'  => 'disabled',
         'wire:loading.class' => '!cursor-wait',
-        'wire:target'        => (strlen($spinner) > 1) ? $spinner : null,
+        'wire:target'        => ($spinner && strlen($spinner) > 1) ? $spinner : null,
     ];
 
     $href === null

--- a/src/Actions/Dialog.php
+++ b/src/Actions/Dialog.php
@@ -12,7 +12,7 @@ class Dialog extends Actionable
     {
         $event = 'dialog';
 
-        if ($id = Str::kebab($dialogId)) {
+        if ($dialogId && $id = Str::kebab($dialogId)) {
             return "{$event}:{$id}";
         }
 

--- a/src/View/Components/BaseButton.php
+++ b/src/View/Components/BaseButton.php
@@ -142,7 +142,7 @@ abstract class BaseButton extends Component
         $modifier  = collect($modifiers)->filter()->keys()->first();
 
         // store the modifier to remove from attributes bag
-        if (!in_array($modifier, $this->smartAttributes)) {
+        if ($modifier && !in_array($modifier, $this->smartAttributes)) {
             $this->smartAttributes[] = $modifier;
         }
 


### PR DESCRIPTION
The following components **Button/Dialog** throw PHP Warnings, This PR will fix/remove it. 

fixes #224 