### PR TITLE
Allow Dropdown component go upwards

### DIFF
--- a/src/View/Components/Dropdown.php
+++ b/src/View/Components/Dropdown.php
@@ -25,8 +25,10 @@ class Dropdown extends Component
     public function getAlign(): string
     {
         $alignments = [
-            'right' => 'origin-top-right right-0',
-            'left'  => 'origin-top-left left-0',
+            'right'     => 'origin-top-right right-0',
+            'left'      => 'origin-top-left left-0',
+            'top-right' => 'origin-top-right right-0 bottom-0',
+            'top-left'  => 'origin-top-left left-0 bottom-0',
         ];
 
         return $alignments[$this->align];


### PR DESCRIPTION
This PR allows dropdown menu to align top right and top left

There is a feature request for this already. #206 

<img width="560" alt="Screen Shot 2022-06-20 at 12 17 24 pm" src="https://user-images.githubusercontent.com/7258887/174514336-4672eba9-21b8-4104-a517-52247f3ffc64.png">

