### PR TITLE
Fix select subcomponents not using unique keys

### DIFF
--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -28,7 +28,7 @@
                 :has-error="$name && $errors->has($name)"
                 :disabled="$disabled"
                 x-on:click="toggle"
-                wire:key="select.label.{{ $name }}">
+                :wire:key="'select.label.'.$name">
             />
         @endif
 

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -28,7 +28,7 @@
                 :has-error="$name && $errors->has($name)"
                 :disabled="$disabled"
                 x-on:click="toggle"
-                :wire:key="'select.label.'.$name">
+                :wire:key="'select.label.' . $name">
             />
         @endif
 
@@ -141,7 +141,7 @@
 
     <x-wireui::parts.popover :margin="(bool) $label" root-class="sm:w-full">
         <template x-if="asyncData.api || (config.searchable && options.length > 10)">
-            <div class="px-2 my-2" wire:key="search.options.{{ $name }}">
+            <div class="px-2 my-2" :wire:key="'search.options.'. $name">
                 <x-dynamic-component
                     :component="WireUi::component('input')"
                     class="bg-slate-100"

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -141,7 +141,7 @@
 
     <x-wireui::parts.popover :margin="(bool) $label" root-class="sm:w-full">
         <template x-if="asyncData.api || (config.searchable && options.length > 10)">
-            <div class="px-2 my-2" :wire:key="'search.options.'. $name">
+            <div class="px-2 my-2" :wire:key="'search.options.' . $name">
                 <x-dynamic-component
                     :component="WireUi::component('input')"
                     class="bg-slate-100"

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -28,7 +28,7 @@
                 :has-error="$name && $errors->has($name)"
                 :disabled="$disabled"
                 x-on:click="toggle"
-                wire:key="select.label"
+                wire:key="select.label.{{ $name }}">
             />
         @endif
 
@@ -141,7 +141,7 @@
 
     <x-wireui::parts.popover :margin="(bool) $label" root-class="sm:w-full">
         <template x-if="asyncData.api || (config.searchable && options.length > 10)">
-            <div class="px-2 my-2" wire:key="search.options">
+            <div class="px-2 my-2" wire:key="search.options.{{ $name }}">
                 <x-dynamic-component
                     :component="WireUi::component('input')"
                     class="bg-slate-100"

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -141,7 +141,7 @@
 
     <x-wireui::parts.popover :margin="(bool) $label" root-class="sm:w-full">
         <template x-if="asyncData.api || (config.searchable && options.length > 10)">
-            <div class="px-2 my-2" :wire:key="'search.options.' . $name">
+            <div class="px-2 my-2" wire:key="search.options.{{ $name }}">
                 <x-dynamic-component
                     :component="WireUi::component('input')"
                     class="bg-slate-100"

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -28,7 +28,7 @@
                 :has-error="$name && $errors->has($name)"
                 :disabled="$disabled"
                 x-on:click="toggle"
-                :wire:key="'select.label.' . $name">
+                :wire:key="'select.label.' . $name"
             />
         @endif
 


### PR DESCRIPTION
While using `select` component, the `label` and `search-options` sub-components doesn't have unique keys. This leads to situations where multiple `select`s are in a page and clicking on it's label brings up menu on another one, labels randomly disappear, etc. This pull request should fix that.

Thanks @donatiss for helping with fix.