### PR TITLE
Set 6 different positions of the notification

### DIFF
--- a/resources/views/components/notifications.blade.php
+++ b/resources/views/components/notifications.blade.php
@@ -1,5 +1,5 @@
 <div class="fixed {{ $zIndex }} inset-0 flex items-end justify-center px-4 py-6
-            pointer-events-none sm:p-5 sm:pt-4 sm:items-start sm:justify-end"
+            pointer-events-none sm:p-5 sm:pt-4 {{ $position }}"
      x-data="wireui_notifications"
      x-on:wireui:notification.window="addNotification($event.detail)"
      x-on:wireui:confirm-notification.window="addConfirmNotification($event.detail)"

--- a/src/View/Components/Notifications.php
+++ b/src/View/Components/Notifications.php
@@ -2,15 +2,44 @@
 
 namespace WireUi\View\Components;
 
+use Illuminate\Support\Str;
 use Illuminate\View\Component;
 
 class Notifications extends Component
 {
     public string $zIndex;
 
-    public function __construct(string $zIndex = 'z-50')
-    {
+    public ?string $position;
+
+    public function __construct(
+        string $zIndex = 'z-50',
+        ?string $position = 'top-right',
+    ) {
         $this->zIndex = $zIndex;
+        $this->position = $this->setPosition($position);
+    }
+
+    public function setPosition($position): string
+    {
+        return Str::of('')
+            ->when($position == 'top-left', function ($string) {
+                return $string->append(' sm:items-start sm:justify-start');
+            })
+            ->when($position == 'top-center', function ($string) {
+                return $string->append(' sm:items-start sm:justify-center');
+            })
+            ->when($position == 'top-right', function ($string) {
+                return $string->append(' sm:items-start sm:justify-end');
+            })
+            ->when($position == 'bottom-left', function ($string) {
+                return $string->append(' sm:items-end sm:justify-start');
+            })
+            ->when($position == 'bottom-center', function ($string) {
+                return $string->append(' sm:items-end sm:justify-center');
+            })
+            ->when($position == 'bottom-right', function ($string) {
+                return $string->append(' sm:items-end sm:justify-end');
+            });
     }
 
     public function render()


### PR DESCRIPTION
Set the global position of the notification on the page
```
<x-notifications position="top-left"/>
<x-notifications position="top-center"/>
<x-notifications position="top-right"/> or <x-notifications/> this is still the default
<x-notifications position="bottom-left"/>
<x-notifications position="bottom-center"/>
<x-notifications position="bottom-right"/>
```

<img width="1268" alt="Screenshot 2022-07-14 at 22 49 06" src="https://user-images.githubusercontent.com/1754421/179083187-139450dc-f999-4302-a56c-47159098ac7d.png">
<img width="1269" alt="Screenshot 2022-07-14 at 22 48 47" src="https://user-images.githubusercontent.com/1754421/179083195-5ed4d3a0-5e58-49f0-b1c5-957af4a433f6.png">
<img width="1288" alt="Screenshot 2022-07-14 at 22 49 32" src="https://user-images.githubusercontent.com/1754421/179083146-620463ee-ff79-4834-a1b8-bd8e5ca3161c.png">
