### PR TITLE
Fix WireUi Scripts Build Version ID

### DIFF
--- a/src/Support/BladeDirectives.php
+++ b/src/Support/BladeDirectives.php
@@ -46,7 +46,7 @@ class BladeDirectives
 
     public function getManifestVersion(string $file, ?string &$route = null): ?string
     {
-        $manifestPath = __DIR__ . '/../dist/mix-manifest.json';
+        $manifestPath = dirname(__DIR__, 2) . '/dist/mix-manifest.json';
 
         if (!file_exists($manifestPath)) {
             return null;


### PR DESCRIPTION
Fix manifest path for add version id to WireUi scripts that removes old cache