### PR TITLE
Fix Select Problem in Mobile

### DIFF
--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -46,7 +46,7 @@
             x-on:keydown.arrow-up.prevent="getPrevFocusable().focus()"
             x-bind:placeholder="getPlaceholder"
             x-bind:value="getSelectedValue"
-            readonly
+            inputmode="none"
             :name="$name"
             {{ $attributes
                 ->except(['class'])


### PR DESCRIPTION
prevent the opening of the keyboard when touching  select on mobile device.
just in searchable select keyboard opens.