### PR TITLE
fix: fix modal and dialog min-height on mozilla

### DIFF
--- a/resources/views/components/dialog.blade.php
+++ b/resources/views/components/dialog.blade.php
@@ -5,8 +5,10 @@
     x-on:wireui:confirm-{{ $dialog }}.window="confirmDialog($event.detail)"
     x-on:keydown.escape.window="handleEscape"
     style="display: none">
-    <div class="flex items-end {{ $align }} sm:pt-16 min-h-screen justify-center"
-        style="min-height: -webkit-fill-available; min-height: fill-available;">
+    <div
+        class="flex items-end {{ $align }} sm:pt-16 min-h-screen justify-center"
+        style="min-height: -webkit-fill-available; min-height: fill-available; min-height: -moz-available;"
+    >
         <div class="fixed inset-0 bg-secondary-400 bg-opacity-60 transform transition-opacity
             {{ $dialog }}-backdrop @if ($blur) {{ $blur }} @endif dark:bg-secondary-700 dark:bg-opacity-60"
             x-show="show"

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -16,9 +16,10 @@
     x-cloak
     x-show="show"
     wireui-modal>
-    <div class="flex items-end {{ $align }} min-h-screen justify-center w-full
-                relative transform transition-all {{ $spacing }}"
-        style="min-height: -webkit-fill-available; min-height: fill-available;">
+    <div
+        class="flex items-end {{ $align }} min-h-screen justify-center w-full relative transform transition-all {{ $spacing }}"
+        style="min-height: -webkit-fill-available; min-height: fill-available; min-height: -moz-available;"
+    >
         <div @class([
                 'fixed inset-0 bg-secondary-400 dark:bg-secondary-700 bg-opacity-60',
                 'dark:bg-opacity-60 transform transition-opacity',


### PR DESCRIPTION
This pr add the styles rules `min-height: -moz-available` on modal and dialog components