### PR TITLE
Added alert component NEW Pull request

### DIFF
--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -1,0 +1,37 @@
+<div {{ $attributes->class($alertClasses) }}>
+    <div class="flex">
+        @if ($icon)
+            <div class="flex-shrink-0">
+                <x-dynamic-component
+                    :component="WireUi::component('icon')"
+                    :name="$icon"
+                    class="h-5 w-5 shrink-0 {{ $subjectColor }}"
+                />
+            </div>
+        @endif
+
+        <div class="ml-3">
+            @if ($title)
+                <h3 class="mb-2 text-sm font-semibold {{ $subjectColor }}">
+                    {{ $title }}
+                </h3>
+            @endif
+
+            <div class="text-sm {{ $subjectColor }}">
+                <p>{{ $message ?? $slot }}</p>
+            </div>
+            
+            @if ($actions)
+                <div class="mt-4">
+                    <div class="-mx-2 -my-1.5 flex">
+                        {{ $actions }}
+                    </div>
+                </div>
+            @endif
+        </div>
+
+        @if ($dismissible)
+            {{ $dismissible }}
+        @endif
+    </div>
+</div>

--- a/src/View/Components/Alert.php
+++ b/src/View/Components/Alert.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace WireUi\View\Components;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
+use Illuminate\View\Component;
+
+class Alert extends Component
+{
+    public string $backgroundColor = 'bg-gray-50 dark:bg-secondary-700';
+
+    public string $subjectColor = 'text-gray-700 dark:text-gray-400';
+
+    public function __construct(
+        public ?string $padding = 'p-4',
+        public ?string $rounded = 'rounded-md',
+        public ?string $icon = null,
+        public ?string $title = null,
+        public ?string $message = null,
+        public ?string $actions = null,
+        public ?string $dismissible = null,
+        public bool $border = false,
+        public bool $shadow = false,
+        public bool $info = false,
+        public bool $warning = false,
+        public bool $positive = false,
+        public bool $negative = false,
+        public ?string $alertClasses = '',
+    ) {
+        $this->getDefaultStyle();
+        $this->alertClasses = $this->getAlertClasses($alertClasses);
+    }
+
+    public function render()
+    {
+        return view('wireui::components.alert');
+    }
+
+    public function getAlertClasses(?string $alertClasses): string
+    {
+        return Str::of('')
+            ->append(" {$this->rounded}")
+            ->append(" {$this->padding}")
+            ->append(" {$this->backgroundColor}")
+            ->append(" {$this->subjectColor}")
+            ->when($this->border, function (Stringable $stringable) {
+                return $stringable->append(' border border-gray-300 dark:border-secondary-600');
+            })
+            ->when($this->shadow, function (Stringable $stringable) {
+                return $stringable->append(' shadow-md');
+            })
+            ->append(" {$alertClasses}");
+    }
+
+    public function getDefaultStyle()
+    {
+        if ($this->info) {
+            $this->icon = (!$this->icon) ? 'information-circle' : $this->icon;
+            $this->backgroundColor = 'bg-blue-50 dark:bg-blue-200';
+            $this->subjectColor = 'text-blue-700 dark:text-blue-800';
+            return true;
+        }
+
+        if ($this->warning) {
+            $this->icon = (!$this->icon) ? 'exclamation' : $this->icon;
+            $this->backgroundColor = 'bg-yellow-50 dark:bg-yellow-200';
+            $this->subjectColor = 'text-yellow-700 dark:text-yellow-800';
+            return true;
+        }
+
+        if ($this->positive) {
+            $this->icon = (!$this->icon) ? 'check-circle' : $this->icon;
+            $this->backgroundColor = 'bg-green-50 dark:bg-green-200';
+            $this->subjectColor = 'text-green-700 dark:text-green-800';
+            return true;
+        }
+
+        if ($this->negative) {
+            $this->icon = (!$this->icon) ? 'x-circle' : $this->icon;
+            $this->backgroundColor = 'bg-red-50 dark:bg-red-200';
+            $this->subjectColor = 'text-red-700 dark:text-red-800';
+            return true;
+        }
+    }
+}

--- a/src/config/wireui.php
+++ b/src/config/wireui.php
@@ -59,6 +59,10 @@ return [
         |
      */
     'components' => [
+        'alert' => [
+            'class' => Components\Alert::class,
+            'alias' => 'alert',
+        ],
         'avatar' => [
             'class' => Components\Avatar::class,
             'alias' => 'avatar',

--- a/tests/Unit/Components/AlertTest.php
+++ b/tests/Unit/Components/AlertTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+
+it('should render the alert slot', function () {
+    $html = Blade::render('<x-alert><b>Text From Slot</b></x-alert>');
+
+    expect($html)->toContain('<b>Text From Slot</b>');
+});
+
+it('should render the alert with default border', function () {
+    $html = Blade::render('<x-alert border message="This is message"/>');
+
+    expect($html)->toContain('border border-gray-300 dark:border-secondary-600');
+});
+
+it('should render the alert with custom classes', function () {
+    $html = Blade::render('<x-alert alertClasses="mt-2 mb-2" message="This is message"/>');
+
+    expect($html)->toContain('mt-2 mb-2');
+});
+
+it('should render the alert with shadow', function () {
+    $html = Blade::render('<x-alert shadow message="This is message"/>');
+
+    expect($html)->toContain('shadow-md');
+});


### PR DESCRIPTION
I merged the main branch into my branch and caused a lot of conflicts, so I just created a new pull request for the alerts. Moved it back to single PHP and single blade file as requested.

![Screenshot 2022-08-26 at 09 14 36](https://user-images.githubusercontent.com/1754421/186844649-216c4483-5653-479e-bd61-ac259378020b.png)

```
<x-alert border alertClasses="my-2">
 Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid pariatur, ipsum similique veniam quo totam eius aperiam dolorum.
</x-alert>
<x-alert icon="user" alertClasses="my-2" padding="p-10" title="test"/>
<x-alert info shadow title="Attention information" message="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid pariatur, ipsum similique veniam quo totam eius aperiam dolorum." alertClasses="my-2"/>
<x-alert warning dismiss message="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid pariatur, ipsum similique veniam quo totam eius aperiam dolorum." alertClasses="my-2" />
<x-alert positive message="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid pariatur, ipsum similique veniam quo totam eius aperiam dolorum." alertClasses="my-2"/>
<x-alert negative shadow border dismiss title="Attention danger" message="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid pariatur, ipsum similique veniam quo totam eius aperiam dolorum." alertClasses="my-2">
    <x-slot name="actions">
        <button type="button" class="bg-red-50 px-2 py-1.5 rounded-md text-sm font-medium text-red-700 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-green-50 focus:ring-green-600">View status</button>
        <button type="button" class="ml-3 bg-red-50 px-2 py-1.5 rounded-md text-sm font-medium text-red-700 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-green-50 focus:ring-green-600">Dismiss</button>
    </x-slot>
</x-alert>
```