### PR TITLE
Dialog overflow contains

### DIFF
--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -11,7 +11,7 @@
         </div>
     @endif
 
-    <div {{ $attributes->merge(['class' => "{$padding} text-secondary-700 grow dark:text-secondary-400"]) }}>
+    <div {{ $attributes->merge(['class' => "{$padding} text-secondary-700 rounded-b-xl grow dark:text-secondary-400"]) }}>
         {{ $slot }}
     </div>
 

--- a/resources/views/components/dialog.blade.php
+++ b/resources/views/components/dialog.blade.php
@@ -28,7 +28,7 @@
         x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
         x-on:mouseenter="pauseTimeout"
         x-on:mouseleave="resumeTimeout">
-        <div class="relative shadow-md bg-white dark:bg-secondary-800 rounded-xl overflow-hidden space-y-4 p-4"
+        <div class="relative shadow-md bg-white dark:bg-secondary-800 rounded-xl space-y-4 p-4"
             :class="{
                 'sm:p-5 sm:pt-7': style === 'center',
                 'sm:p-0':         style === 'inline',
@@ -76,7 +76,7 @@
                 </div>
             </div>
 
-            <div class="grid grid-cols-1 gap-y-2 sm:gap-x-3"
+            <div class="grid grid-cols-1 gap-y-2 sm:gap-x-3 rounded-b-xl"
                 :class="{
                     'sm:grid-cols-2 sm:gap-y-0': style === 'center',
                     'sm:p-4 sm:bg-secondary-100 sm:dark:bg-secondary-800 sm:grid-cols-none sm:flex sm:justify-end': style === 'inline',


### PR DESCRIPTION
This solves the visualization problem when you use a custom dialog with a select or other fields that overflow the dialog area

Before
![image](https://user-images.githubusercontent.com/497169/188264990-9eba39a1-2380-4563-aa2c-add17fa9abda.png)


After
![image](https://user-images.githubusercontent.com/497169/188264994-99b19ace-3c2b-430e-bc8b-be578770a702.png)
![image](https://user-images.githubusercontent.com/497169/188265001-94c4e0d6-83dc-4a5b-8845-b5abdcc7876b.png)
