### PR TITLE
Extended Modal and added modal.slider modal that slides from the side

### DIFF
--- a/resources/views/components/modal-slider.blade.php
+++ b/resources/views/components/modal-slider.blade.php
@@ -49,14 +49,14 @@
                     x-transition:leave-start="translate-x-0"
                     x-transition:leave-end="translate-x-full"
                 >
-                    <div class="flex h-full flex-col divide-y divide-secondary-200 bg-white shadow-xl">
+                    <div class="flex h-full flex-col divide-y divide-secondary-200 dark:divide-secondary-500 bg-white dark:bg-secondary-800 shadow-xl">
                         <div class="flex min-h-0 flex-1 flex-col overflow-y-scroll py-6">
                             <div class="px-4 sm:px-6 pb-6 border-b dark:border-0">
                                 <div class="flex items-start justify-between">
                                     @isset($header)
                                         {{ $header }}
                                     @else
-                                        <h2 class="text-lg font-medium text-gray-900" id="slide-over-title">{{ $title }}</h2>
+                                        <h2 class="text-lg font-medium text-gray-900 dark:text-secondary-400" id="slide-over-title">{{ $title }}</h2>
                                         <div class="ml-3 flex h-7 items-center">
                                             <button class="focus:outline-none p-1 focus:ring-2 focus:ring-secondary-200 rounded-full text-secondary-300"
                                                     x-on:click="close"
@@ -72,7 +72,7 @@
                                 </div>
                             </div>
 
-                            <div class="relative mt-2 flex-1 px-4 sm:px-6 {{ $spacing }}">
+                            <div class="relative mt-2 flex-1 px-4 sm:px-6 dark:text-secondary-400 {{ $spacing }}">
                                 {{ $slot }}
                             </div>
 

--- a/resources/views/components/modal-slider.blade.php
+++ b/resources/views/components/modal-slider.blade.php
@@ -1,0 +1,90 @@
+@php($name = $name ?? $attributes->wire('model')->value())
+
+<div class="fixed inset-0 overflow-y-auto {{ $zIndex }}"
+     x-data="wireui_modal({
+        show: @toJs($show),
+        @if ($attributes->wire('model')->value())
+            model: @entangle($attributes->wire('model'))
+        @endif
+    })"
+     x-on:keydown.escape.window="handleEscape"
+     x-on:keydown.tab.prevent="handleTab"
+     x-on:keydown.shift.tab.prevent="handleShiftTab"
+     x-on:open-wireui-modal:{{ Str::kebab($name) }}.window="open"
+     {{ $attributes
+         ->whereDoesntStartWith('wire:model')
+         ->whereStartsWith(['x-on:', '@', 'wire:']) }}
+     style="display: none"
+     x-cloak
+     x-show="show"
+     wireui-modal>
+
+    <div
+        @class([
+            'fixed inset-0 bg-secondary-400 dark:bg-secondary-700 bg-opacity-60',
+            'dark:bg-opacity-60 transform transition-opacity',
+            $blur => (bool) $blur
+        ])
+        x-show="show"
+        x-on:click="close"
+        x-transition:enter="ease-in-out duration-500"
+        x-transition:enter-start="opacity-0"
+        x-transition:enter-end="opacity-100"
+        x-transition:leave="ease-in-out duration-500"
+        x-transition:leave-start="opacity-100"
+        x-transition:leave-end="opacity-0">
+    </div>
+
+    <div class="fixed inset-0 overflow-hidden">
+        <div class="absolute inset-0 overflow-hidden">
+            <div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10">
+                <div
+                    x-show="show"
+                    x-on:click.self="close"
+                    class="pointer-events-auto relative w-screen {{ $maxWidth }}"
+                    x-transition:enter="transform transition ease-in-out duration-500 sm:duration-700"
+                    x-transition:enter-start="translate-x-full"
+                    x-transition:enter-end="translate-x-0"
+                    x-transition:leave="transform transition ease-in-out duration-500 sm:duration-700"
+                    x-transition:leave-start="translate-x-0"
+                    x-transition:leave-end="translate-x-full"
+                >
+                    <div class="flex h-full flex-col divide-y divide-secondary-200 bg-white shadow-xl">
+                        <div class="flex min-h-0 flex-1 flex-col overflow-y-scroll py-6">
+                            <div class="px-4 sm:px-6 pb-6 border-b dark:border-0">
+                                <div class="flex items-start justify-between">
+                                    @isset($header)
+                                        {{ $header }}
+                                    @else
+                                        <h2 class="text-lg font-medium text-gray-900" id="slide-over-title">{{ $title }}</h2>
+                                        <div class="ml-3 flex h-7 items-center">
+                                            <button class="focus:outline-none p-1 focus:ring-2 focus:ring-secondary-200 rounded-full text-secondary-300"
+                                                    x-on:click="close"
+                                                    tabindex="-1">
+                                                <x-dynamic-component
+                                                    :component="WireUi::component('icon')"
+                                                    name="x"
+                                                    class="w-5 h-5"
+                                                />
+                                            </button>
+                                        </div>
+                                    @endif
+                                </div>
+                            </div>
+
+                            <div class="relative mt-2 flex-1 px-4 sm:px-6 {{ $spacing }}">
+                                {{ $slot }}
+                            </div>
+
+                        </div>
+
+                        @isset($footer)
+                            {{ $footer }}
+                        @endisset
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/resources/views/components/modal-slider.blade.php
+++ b/resources/views/components/modal-slider.blade.php
@@ -41,16 +41,17 @@
                 <div
                     x-show="show"
                     x-on:click.self="close"
-                    class="pointer-events-auto relative w-screen {{ $maxWidth }}"
                     x-transition:enter="transform transition ease-in-out duration-500 sm:duration-700"
                     x-transition:enter-start="translate-x-full"
                     x-transition:enter-end="translate-x-0"
                     x-transition:leave="transform transition ease-in-out duration-500 sm:duration-700"
                     x-transition:leave-start="translate-x-0"
                     x-transition:leave-end="translate-x-full"
+                    class="pointer-events-auto relative w-screen {{ $maxWidth }}"
                 >
                     <div class="flex h-full flex-col divide-y divide-secondary-200 dark:divide-secondary-500 bg-white dark:bg-secondary-800 shadow-xl">
                         <div class="flex min-h-0 flex-1 flex-col overflow-y-scroll py-6">
+
                             <div class="px-4 sm:px-6 pb-6 border-b dark:border-0">
                                 <div class="flex items-start justify-between">
                                     @isset($header)
@@ -81,6 +82,7 @@
                         @isset($footer)
                             {{ $footer }}
                         @endisset
+
                     </div>
                 </div>
             </div>

--- a/src/View/Components/ModalSlider.php
+++ b/src/View/Components/ModalSlider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace WireUi\View\Components;
+
+class ModalSlider extends Modal
+{
+    public function __construct(
+        public ?string $name = null,
+        public ?string $zIndex = null,
+        public ?string $maxWidth = null,
+        public ?string $spacing = null,
+        public ?string $align = null,
+        public string|bool|null $blur = null,
+        public bool $show = false,
+        public string $padding = 'px-2 py-5 md:px-4',
+        public string $rounded = 'rounded-xl',
+        public string $shadow = 'shadow-md',
+        public string $divider = 'divide-y divide-secondary-200',
+        public ?string $title = null,
+        public ?string $header = null,
+        public ?string $footer = null,
+        public bool $fullscreen = false,
+        public bool $squared = false,
+        public bool $hideClose = false,
+    ) {
+        if ($fullscreen) {
+            $maxWidth = '';
+        }
+
+        parent::__construct(
+            name: $name,
+            zIndex: $zIndex,
+            maxWidth: $maxWidth,
+            spacing: $spacing,
+            align: $align,
+            blur: $blur,
+            show: $show
+        );
+    }
+
+    public function render()
+    {
+        return view('wireui::components.modal-slider');
+    }
+}

--- a/src/config/wireui.php
+++ b/src/config/wireui.php
@@ -187,9 +187,13 @@ return [
             'class' => Components\ModalCard::class,
             'alias' => 'modal.card',
         ],
+        'modal.slider' => [
+            'class' => Components\ModalSlider::class,
+            'alias' => 'modal.slider',
+        ],
         'dialog' => [
             'class' => Components\Dialog::class,
             'alias' => 'dialog',
-        ],
+        ]
     ],
 ];


### PR DESCRIPTION
```php
<x-button onclick="$openModal('simpleSlider')" label="Open Slider"/>

<x-modal.slider title="Slider Title" wire:model.defer="simpleSlider">
    Lorem Ipsum is simply ...
    <x-slot name="footer">
        <div class="flex flex-shrink-0 justify-end px-4 py-4 space-x-4 sm:px-6 bg-secondary-50 rounded-t-none border-t dark:bg-secondary-800 dark:border-secondary-600">
            <x-button flat label="Cancel" x-on:click="close" />
            <x-button primary label="I Agree" />
        </div>
    </x-slot>
</x-modal.slider>
```
![Screenshot 2022-09-05 at 20 21 40](https://user-images.githubusercontent.com/1754421/188500418-8a47c580-879b-4de9-ba25-9fb207d25478.png)

