### PR TITLE
Add support for credentials when using async-data

### DIFF
--- a/ts/components/select/index.ts
+++ b/ts/components/select/index.ts
@@ -296,7 +296,7 @@ export default (initOptions: InitOptions): Select => ({
     const request = new Request(url, {
       method,
       body: method === 'POST' ? JSON.stringify(parameters) : undefined,
-      credentials: credentials ?? 'omit'
+      credentials
     })
 
     request.headers.set('Content-Type', 'application/json')

--- a/ts/components/select/index.ts
+++ b/ts/components/select/index.ts
@@ -244,7 +244,8 @@ export default (initOptions: InitOptions): Select => ({
       api: props.asyncData.api,
       method: props.asyncData.method,
       params: props.asyncData.params,
-      alwaysFetch: props.asyncData.alwaysFetch
+      alwaysFetch: props.asyncData.alwaysFetch,
+      credentials: props.asyncData.credentials
     }
   },
   syncJsonOptions () {
@@ -276,7 +277,9 @@ export default (initOptions: InitOptions): Select => ({
     }
   },
   makeRequest (params = {}) {
-    const { api, method } = this.asyncData
+    const { api, method, credentials } = this.asyncData
+
+    console.log(this.asyncData);
 
     const url = new URL(api ?? '')
 
@@ -294,7 +297,8 @@ export default (initOptions: InitOptions): Select => ({
 
     const request = new Request(url, {
       method,
-      body: method === 'POST' ? JSON.stringify(parameters) : undefined
+      body: method === 'POST' ? JSON.stringify(parameters) : undefined,
+      credentials: credentials ?? 'omit'
     })
 
     request.headers.set('Content-Type', 'application/json')

--- a/ts/components/select/index.ts
+++ b/ts/components/select/index.ts
@@ -279,8 +279,6 @@ export default (initOptions: InitOptions): Select => ({
   makeRequest (params = {}) {
     const { api, method, credentials } = this.asyncData
 
-    console.log(this.asyncData);
-
     const url = new URL(api ?? '')
 
     const parameters = Object.assign(

--- a/ts/components/select/types.ts
+++ b/ts/components/select/types.ts
@@ -25,7 +25,7 @@ export type AsyncDataConfig = {
   method: string
   params: any
   alwaysFetch: boolean,
-  credentials?: "include" | "omit" | "same-origin"
+  credentials?: 'include' | 'omit' | 'same-origin'
 }
 
 export type AsyncData = AsyncDataConfig & {

--- a/ts/components/select/types.ts
+++ b/ts/components/select/types.ts
@@ -24,7 +24,8 @@ export type AsyncDataConfig = {
   api: string | null
   method: string
   params: any
-  alwaysFetch: boolean
+  alwaysFetch: boolean,
+  credentials?: "include" | "omit" | "same-origin"
 }
 
 export type AsyncData = AsyncDataConfig & {

--- a/ts/components/select/types.ts
+++ b/ts/components/select/types.ts
@@ -25,7 +25,7 @@ export type AsyncDataConfig = {
   method: string
   params: any
   alwaysFetch: boolean,
-  credentials?: 'include' | 'omit' | 'same-origin'
+  credentials?: RequestCredentials
 }
 
 export type AsyncData = AsyncDataConfig & {


### PR DESCRIPTION
This little PR adds support for the `credentials` option while fetching.
This is necessary when using sub domains for fetching async data, like for example with Laravel Passport or Sanctum.

Here's the documentation of the `credentials` option:
https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#sending_a_request_with_credentials_included