### PR TITLE
Add support for html in label

### DIFF
--- a/resources/views/components/label.blade.php
+++ b/resources/views/components/label.blade.php
@@ -4,5 +4,5 @@
         'opacity-60'         => $attributes->get('disabled'),
         'text-gray-700 dark:text-gray-400' => !$hasError,
     ]) }}>
-    {{ $label ?? $slot }}
+    {!! $label ?? $slot !!}
 </label>


### PR DESCRIPTION
Add html in labels
```php
    <x-toggle wire:model.defer="agree" lg>
        <x-slot name="label">
            By selecting this, you agree to the
            <a href="#" class="font-medium text-gray-700 underline">Privacy Policy</a>
            and
            <a href="#" class="font-medium text-gray-700 underline">Cookie Policy</a>.
        </x-slot>
    </x-toggle>

```