### PR TITLE
Vertically align cornerHint to label base above input

### DIFF
--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -4,7 +4,7 @@
 
 <div class="@if($disabled) opacity-60 @endif">
     @if ($label || $cornerHint)
-        <div class="flex {{ !$label && $cornerHint ? 'justify-end' : 'justify-between' }} mb-1">
+        <div class="flex {{ !$label && $cornerHint ? 'justify-end' : 'justify-between items-end' }} mb-1">
             @if ($label)
                 <x-dynamic-component
                     :component="WireUi::component('label')"


### PR DESCRIPTION
This is a small alignment tweak.

When changing the text size of the input corner hint the vertical misalignment becomes obvious:

<img width="503" alt="Screen Shot 2022-12-19 at 1 48 02 PM" src="https://user-images.githubusercontent.com/522158/208508247-195b418d-884f-472d-ba6c-2e22c75d5d9c.png">

After this change the corner hint will be aligned to the base of the label above the input:

<img width="506" alt="Screen Shot 2022-12-19 at 1 48 14 PM" src="https://user-images.githubusercontent.com/522158/208508259-14fd7a62-bc04-49b8-843f-ec1a91541a2a.png">