### PR TITLE
bugfix: x-select options do not refresh

### DIFF
--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -218,7 +218,8 @@
             @endisset
 
             <ul x-ref="listing" wire:ignore>
-                <template x-for="(option, index) in displayOptions" :key="`${index}.${option.value}`">
+                <template x-for="(option, index) in displayOptions"
+                          :key="`${index}.${option.value}${option.label || ''}`">
                     <li tabindex="-1" :index="index">
                         <div class="px-2 py-0.5">
                             <div class="h-8 w-full animate-pulse bg-slate-200 dark:bg-slate-600 rounded"></div>

--- a/ts/components/select/index.ts
+++ b/ts/components/select/index.ts
@@ -258,32 +258,36 @@ export default (initOptions: InitOptions): Select => ({
     }
   },
   syncJsonOptions () {
-    this.setOptions(window.Alpine.evaluate(this, this.$refs.json.innerText))
+    setTimeout(() => {
+      this.setOptions(window.Alpine.evaluate(this, this.$refs.json.innerText))
 
-    if (this.hasWireModel) {
-      this.syncSelectedFromWireModel()
-    }
+      if (this.hasWireModel) {
+        this.syncSelectedFromWireModel()
+      }
+    })
   },
   syncSlotOptions () {
-    const elements = this.$refs.slot.querySelectorAll('[name="wireui.select.option"]')
-
-    const options = Array.from(elements).flatMap(element => {
-      const base64 = element.querySelector('[name="wireui.select.option.data"]')?.textContent
-
-      if (!base64) return []
-
-      const option: Option = window.Alpine.evaluate(this, base64)
-
-      option.html = element.querySelector('[name="wireui.select.slot"]')?.innerHTML
-
-      return option
+    setTimeout(() => {
+      const elements = this.$refs.slot.querySelectorAll('[name="wireui.select.option"]')
+      
+      const options = Array.from(elements).flatMap(element => {
+        const base64 = element.querySelector('[name="wireui.select.option.data"]')?.textContent
+        
+        if (!base64) return []
+        
+        const option: Option = window.Alpine.evaluate(this, base64)
+        
+        option.html = element.querySelector('[name="wireui.select.slot"]')?.innerHTML
+        
+        return option
+      })
+      
+      this.setOptions(options)
+      
+      if (this.hasWireModel) {
+        this.syncSelectedFromWireModel()
+      }
     })
-
-    this.setOptions(options)
-
-    if (this.hasWireModel) {
-      this.syncSelectedFromWireModel()
-    }
   },
   makeRequest (params = {}) {
     const { api, method, credentials } = this.asyncData


### PR DESCRIPTION
Slot-provided and attribute-provided options passed to `Select` (`<x-select />`) may fail to refresh/redraw if more than one of `Select`'s properties is updated during Livewire's lifecycle.

Consider the following:

<p align="right"><strong><code>StyleEditor.php</code></strong></p>

```php
class StyleEditor {
  public ?Product $product = null;

  public ?string $selectedOption = null;
  public ?string $optionValue = null;

  public function getStyleOptionsProperty()
  {
    return collect($this->product->styleOptions)
      ->pluck('name')
      ->toArray();
  }

  public function getStyleValueOptionsProperty()
  {
    return blank($this->selectedOption) ?
      [] : collect($this->product->styles)
        ->firstWhere('name', $this->selectedOption)['options'];
  }
}
```

<p align="right"><strong><code>style-editor.blade.php</code></strong></p>

```blade
@isset($this->product)
  <div>
    <x-select label="Style" :options="$this->styleOptions" wire:model="selectedOption" />
    <x-select label="Setting" 
            :options="$this->styleValueOptions"
            wire:model="optionValue"
            :disabled="blank($this->selectedOption)"/>
  </div>
@endisset
```

The mutability of and the options available to the second `<x-select>` are dependent upon the value mutated by the first `<x-select>` — `selectedOption`. When `selectedOption` changes, Livewire will re-compute the value for `styleValueOptions`, and the available options in the dependent `<x-select>` should change. Presently this does not occur.

Changes to the markup can be observed in the inspector, but they are not picked-up by the `MutationObserver` upon which WireUi depends to reflect changes in AlpineJS. To account for this, mutation-invoked operations should be deferred until the end of the current events cycle — after Livewire and AlpineJS has finished manipulating the DOM. In the PR, I have wrapped the `syncJsonOptions()` and `syncSlotOptions()` inside of a `setTimeout()` to do this. Other methods may be feasible or preferred.

Further, it is necessary to include the option label in the `key` property of each `<li>` provided to AlpineJS in the `x-for` used to display the popover options. When a set of options includes options with index and value parity — but not label parity — AlpineJS will not draw the updated label.

---

I appreciate your insights and thoughts on these considerations, as well as your ongoing work with WireUi. It is a blessing and gift to Laravel and Livewire.