### PR TITLE
fix(select): image cover for avatar

### DIFF
--- a/ts/components/select/templates/userOption.ts
+++ b/ts/components/select/templates/userOption.ts
@@ -32,7 +32,7 @@ export const template: UserInitTemplate = (config): UserTemplate => ({
   renderSelected (option) {
     return `
       <div class="flex items-center gap-x-3">
-        <img src="${this.getSrc(option)}" class="shrink-0 h-6 w-6 rounded-full">
+        <img src="${this.getSrc(option)}" class="shrink-0 h-6 w-6 object-cover rounded-full">
 
         <span>${option.label}</span>
       </div>


### PR DESCRIPTION
**What this PR does?**
It fixes the avatar image for non 1:1 aspect ratio images.

Before:
<img width="481" alt="image" src="https://user-images.githubusercontent.com/3236791/217984400-b3ade40a-92b3-477f-93d2-c5f225405802.png">

After: 
<img width="445" alt="image" src="https://user-images.githubusercontent.com/3236791/217984759-698f512c-ead4-4c2a-afce-1dc1e5a6ba79.png">

