### PR TITLE
ide.json file for IDE completions for Blade components

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://laravel-ide.com/schema/laravel-ide-v2.json",
+    "blade": {
+        "components": {
+            "fromConfig": [
+                {
+                    "configFileName": "wireui",
+                    "componentsKey": "components",
+                    "classFetch": {
+                        "type": "arrayKey",
+                        "key": "class"
+                    },
+                    "aliasKey": "alias"
+                }
+            ],
+            "ignoreViewPaths": [
+                "resources/views"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Laravel Idea PhpStorm plugin(and maybe other IDE plugins in the future) can use this file and complete components correctly.

<img width="348" alt="image" src="https://user-images.githubusercontent.com/2818394/232990937-0f0c34ba-46f6-46a8-a8e0-7adfabd2bb81.png">

<img width="334" alt="image" src="https://user-images.githubusercontent.com/2818394/232991100-afc0ba9d-a727-40e9-a113-794d1789dc9d.png">
