### PR TITLE
(fix) Allow html inside label

### DIFF
--- a/resources/views/components/label.blade.php
+++ b/resources/views/components/label.blade.php
@@ -4,5 +4,5 @@
         'opacity-60'         => $attributes->get('disabled'),
         'text-gray-700 dark:text-gray-400' => !$hasError,
     ]) }}>
-    {{ $label ?? $slot }}
+    {!! $label ?? $slot !!}
 </label>


### PR DESCRIPTION
add ability to have:
```blade
<x-toggle wire:model="agree" lg>
    <x-slot name="label">
        {{ __("By selecting this, you agree to the") }}
        <a href="#" class="font-medium text-gray-700 underline">{{ __("Privacy Policy") }}</a>
        {{ __("and") }}
        <a href="#" class="font-medium text-gray-700 underline">{{ __("Cookie Policy") }}</a>.
    </x-slot>
</x-toggle>
```