### PR TITLE
add trix component

### DIFF
--- a/resources/views/components/trix.blade.php
+++ b/resources/views/components/trix.blade.php
@@ -1,0 +1,73 @@
+@php
+    $hasError = $name && $errors->has($name);
+@endphp
+
+<div wire:ignore>
+
+    {{-- css section --}}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/trix/1.3.1/trix.min.css" />
+
+    {{-- label --}}
+    @if ($label)
+        <x-dynamic-component
+            :component="WireUi::component('label')"
+            :label="$label"
+            :has-error="$hasError"
+            :for="$id"
+        />
+    @endif
+
+    {{-- trix editor section --}}
+    <input id="{{ $trixId }}" type="hidden" name="{{ $name }}" value="{{ $value }}">
+    <trix-editor wire:ignore input="{{ $trixId }}"></trix-editor>
+
+    {{-- scripts section --}}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/trix/1.3.1/trix.min.js"></script>
+    <script>
+        var trixEditor = document.getElementById("{{ $trixId }}")
+        var mimeTypes = ["image/png", "image/jpeg", "image/jpg"];
+
+        addEventListener("trix-blur", function(event) {
+            @this.set("{{$name}}", trixEditor.getAttribute("value"))
+        });
+
+        addEventListener("trix-file-accept", function(event) {
+            if (! mimeTypes.includes(event.file.type) ) {
+                // file type not allowed, prevent default upload
+                return event.preventDefault();
+            }
+        });
+
+        addEventListener("trix-attachment-add", function(event){
+            uploadTrixImage(event.attachment);
+        });
+
+        function uploadTrixImage(attachment){
+            // upload with livewire
+            @this.upload(
+                'photos',
+                attachment.file,
+                function (uploadedURL) {
+
+                    // We need to create a custom event.
+                    // This event will create a pause in thread execution until we get the Response URL from the Trix Component @completeUpload
+                    const trixUploadCompletedEvent = `trix-upload-completed:${btoa(uploadedURL)}`;
+                    const trixUploadCompletedListener = function(event) {
+                        attachment.setAttributes(event.detail);
+                        window.removeEventListener(trixUploadCompletedEvent, trixUploadCompletedListener);
+                    }
+
+                    window.addEventListener(trixUploadCompletedEvent, trixUploadCompletedListener);
+
+                    // call the Trix Component @completeUpload below
+                    @this.call('completeUpload', uploadedURL, trixUploadCompletedEvent);
+                },
+                function() {},
+                function(event){
+                    attachment.setUploadProgress(event.detail.progress);
+                },
+            )
+            // complete the upload and get the actual file URL
+        }
+    </script>
+</div>

--- a/src/View/Components/Trix.php
+++ b/src/View/Components/Trix.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WireUi\View\Components;
+
+use Illuminate\Support\{Str, Stringable};
+
+class Trix extends FormComponent
+{
+    public function __construct(
+        public ?string $label = '',
+        public ?string $name = '',
+        public ?string $value = '',
+        public ?string $trixId = '',
+    ) {
+        $this->label = $label;
+        $this->name = $name;
+        $this->value = $value;
+        $this->trixId = 'trix-' . uniqid();
+    }
+
+    public function getView(): string
+    {
+        return 'wireui::components.trix';
+    }
+}

--- a/src/config/wireui.php
+++ b/src/config/wireui.php
@@ -199,5 +199,9 @@ return [
             'class' => Components\Dialog::class,
             'alias' => 'dialog',
         ],
+        'trix' => [
+            'class' => Components\Trix::class,
+            'alias' => 'trix',
+        ],
     ],
 ];

--- a/tests/Unit/Components/SelectTest.php
+++ b/tests/Unit/Components/SelectTest.php
@@ -10,7 +10,7 @@ class SelectTest extends UnitTestCase
     /** @test */
     public function It_should_throw_an_error_if_async_data_and_options_is_set_together()
     {
-        $this->expectErrorMessage('The {async-data} attribute cannot be used with {options} attribute.');
+        $this->expectExceptionMessage('The {async-data} attribute cannot be used with {options} attribute.');
 
         new Select(asyncData: 'http://example.com/api/options', options: ['name' => 'Option 1']);
     }

--- a/tests/Unit/Controllers/ButtonControllerTest.php
+++ b/tests/Unit/Controllers/ButtonControllerTest.php
@@ -65,61 +65,61 @@ class ButtonControllerTest extends UnitTestCase
                 'attributes' => [
                     'color' => 'invalid-color',
                 ],
-                'errors' => ['color' => 'validation.in'],
+                'errors' => ['color'],
             ],
             'size' => [
                 'attributes' => [
                     'size' => 'invalid-size',
                 ],
-                'errors' => ['size' => 'validation.in'],
+                'errors' => ['size'],
             ],
             'iconSize' => [
                 'attributes' => [
                     'iconSize' => 'invalid-iconSize',
                 ],
-                'errors' => ['iconSize' => 'validation.in'],
+                'errors' => ['iconSize'],
             ],
             'label' => [
                 'attributes' => [
                     'label' => ['invalid-type'],
                 ],
-                'errors' => ['label' => 'string'],
+                'errors' => ['label'],
             ],
             'rightIcon' => [
                 'attributes' => [
                     'rightIcon' => ['invalid-type'],
                 ],
-                'errors' => ['rightIcon' => 'string'],
+                'errors' => ['rightIcon'],
             ],
             'icon' => [
                 'attributes' => [
                     'icon' => ['invalid-type'],
                 ],
-                'errors' => ['icon' => 'string'],
+                'errors' => ['icon'],
             ],
             'rounded' => [
                 'attributes' => [
                     'rounded' => ['invalid-type'],
                 ],
-                'errors' => ['rounded' => 'boolean'],
+                'errors' => ['rounded'],
             ],
             'squared' => [
                 'attributes' => [
                     'squared' => ['invalid-type'],
                 ],
-                'errors' => ['squared' => 'boolean'],
+                'errors' => ['squared'],
             ],
             'bordered' => [
                 'attributes' => [
                     'bordered' => ['invalid-type'],
                 ],
-                'errors' => ['bordered' => 'boolean'],
+                'errors' => ['bordered'],
             ],
             'flat' => [
                 'attributes' => [
                     'flat' => ['invalid-type'],
                 ],
-                'errors' => ['flat' => 'boolean'],
+                'errors' => ['flat'],
             ],
         ];
     }


### PR DESCRIPTION
this pull request add trix editor component & support for attach image

example usage:

in a blade file
```
<form wire:submit.prevent="save">

    <div class="p-6 text-gray-900">
        <x-trix label="Content" name="content" value="{{$content}}" />
        <x-error name="content" />
    </div>

    <x-primary-button class="ml-3">
        Save
    </x-primary-button>

</form>
```

in a livewire class component
```
    use WithFileUploads;

    const EVENT_VALUE_UPDATED = 'trix_value_updated';

    public $content;
    public $trixId;
    public $photos = [];

    public function mount()
    {
        $this->content = '';
        $this->trixId = 'trix-' . uniqid();
    }

    public function updatedValue($content){
        $this->emit(self::EVENT_VALUE_UPDATED, $this->content);
    }

    public function completeUpload(string $uploadedUrl, string $trixUploadCompletedEvent){

        foreach($this->photos as $photo){
            if($photo->getFilename() == $uploadedUrl) {
                // store in the public/photos location
                $newFilename = $photo->store('public/photos');

                // get the public URL of the newly uploaded file
                $url = Storage::url($newFilename);

                $this->dispatchBrowserEvent($trixUploadCompletedEvent, [
                    'url' => $url,
                    'href' => $url,
                ]);
            }
        }
    }

    public function render()
    {
        return view('livewire.dashboard');
    }

    public function save()
    {
        $this->validate(['content' => 'required']);
        dd($this->content);
    }
```