### PR TITLE
Fix inputs wire:keydown and wire:keyup

### DIFF
--- a/resources/views/components/inputs/currency.blade.php
+++ b/resources/views/components/inputs/currency.blade.php
@@ -8,7 +8,7 @@
 })" {{ $attributes->only('wire:key') }}>
     <x-dynamic-component
         :component="WireUi::component('input')"
-        {{ $attributes->whereDoesntStartWith(['wire:model', 'wire:key'])->except('type') }}
+        {{ $attributes->whereDoesntStartWith(['wire:model'])->except(['type', 'wire:key']) }}
         :borderless="$borderless"
         :shadowless="$shadowless"
         :label="$label"

--- a/resources/views/components/inputs/maskable.blade.php
+++ b/resources/views/components/inputs/maskable.blade.php
@@ -20,6 +20,6 @@
         x-model="input"
         x-on:input="onInput($event.target.value)"
         x-on:blur="emitInput"
-        {{ $attributes->whereDoesntStartWith(['wire:model', 'x-model', 'wire:key']) }}
+        {{ $attributes->whereDoesntStartWith(['wire:model', 'x-model'])->except('wire:key') }}
     />
 </div>

--- a/resources/views/components/inputs/number.blade.php
+++ b/resources/views/components/inputs/number.blade.php
@@ -9,7 +9,7 @@
         inputmode="numeric"
         {{ $attributes
             ->class('text-center appearance-number-none')
-            ->whereDoesntStartWith('wire:key')
+            ->except('wire:key')
             ->except($except) }}
         :borderless="$borderless"
         :shadowless="$shadowless"

--- a/resources/views/components/inputs/password.blade.php
+++ b/resources/views/components/inputs/password.blade.php
@@ -1,7 +1,7 @@
 <div x-data="wireui_inputs_password" {{ $attributes->only('wire:key') }}>
     <x-dynamic-component
         :component="WireUi::component('input')"
-        {{ $attributes->whereDoesntStartWith('wire:key') }}
+        {{ $attributes->except('wire:key') }}
         :borderless="$borderless"
         :shadowless="$shadowless"
         :label="$label"


### PR DESCRIPTION
Hello,

in my login form, i use `x-inputs.password`. After entering the password, the user should press the enter key to login.
`<x-inputs.password label="Password" wire:keydown.enter="login" wire:model.defer="password"/>`

But `wire:keydown.enter="login"` will not working.

The reason why it doesn't work is `$attributes->whereDoesntStartWith(['wire:key'])` include attributes like `wire:keydown` and `wire:keyup`.

This PR will solves this problem.