### PR TITLE
Allow passing html into labels

### DIFF
--- a/resources/views/components/label.blade.php
+++ b/resources/views/components/label.blade.php
@@ -4,5 +4,5 @@
         'opacity-60'         => $attributes->get('disabled'),
         'text-gray-700 dark:text-gray-400' => !$hasError,
     ]) }}>
-    {{ $label ?? $slot }}
+    @if($label) {{ $label }} @else {!! $slot !!} @endif
 </label>


### PR DESCRIPTION
This has been proposed multiple times #685 #510 

I understand your concern; it may appear to be a security vulnerability, but it doesn't have to be if done the way I propose. This is because if they use a slot, the content is already escaped before being passed into the slot.

From the example #685  gave:
```blade
<x-toggle wire:model="agree" lg>
    <x-slot name="label">
        {{ __("By selecting this, you agree to the") }}  {{-- <---- This here is already escaped before being passed into the slot. so it's safe. ---> --}}
        <a href="#" class="font-medium text-gray-700 underline">{{ __("Privacy Policy") }}</a>
        {{ __("and") }} {{ --- Same as this --}}
        <a href="#" class="font-medium text-gray-700 underline">{{ __("Cookie Policy") }}</a>.
    </x-slot>
</x-toggle>
```

Even when passing potentially dangerous user inputs, it remains safe. As mentioned, using `{{ ... }}` within the slot automatically escapes it before rendering in the slot.

```blade
<x-toggle wire:model="agree" lg>
    <x-slot name="label">
        Hello, {{ $potentiallyXSSUsername }} {{-- This is safe because I used  {{... }} as is meant to be done, thus escaping it --}}
    </x-slot>
</x-toggle>
````

In fact, the current approach is problematic as it escapes content twice, sometimes converting quotation marks to HTML entities. Not to mention, the current method makes it impossible to pass html into slots, _which is the entire reason we may use slots rather than attributes_

My pull request is simple:
`{{ $label ?? $slot }}` to `@if($label) {{ $label }} @else {!! $slot !!} @endif `

This way, if the user passes content (which should be text content only, not html), directly through the label attribute, it is automatically escaped, but if they use slots, it is not escaped, because as the example above shows, passing user data through slots is automatically safe.