### PR TITLE
Add support for preventing modal outside click close

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -24,7 +24,9 @@
             $blur => (bool) $blur
         ])
         x-show="show"
-        x-on:click="close"
+        @if(! $attributes->get('prevent-outside-close'))
+            x-on:click="close"
+        @endif
         x-transition:enter="ease-out duration-300"
         x-transition:enter-start="opacity-0"
         x-transition:enter-end="opacity-100"
@@ -35,7 +37,9 @@
 
     <div class="w-full min-h-full transform flex items-end justify-center mx-auto {{ $align }} {{ $maxWidth }}"
         x-show="show"
-        x-on:click.self="close"
+        @if(! $attributes->get('prevent-outside-close'))
+            x-on:click.self="close"
+        @endif
         x-transition:enter="ease-out duration-300"
         x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
         x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -37,9 +37,9 @@
 
     <div class="w-full min-h-full transform flex items-end justify-center mx-auto {{ $align }} {{ $maxWidth }}"
         x-show="show"
-        @if(! $persistent)
+        @unless($persistent)
             x-on:click.self="close"
-        @endif
+        @unless
         x-transition:enter="ease-out duration-300"
         x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
         x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -24,7 +24,7 @@
             $blur => (bool) $blur
         ])
         x-show="show"
-        @if(! $attributes->get('prevent-outside-close'))
+        @if(! $persistent)
             x-on:click="close"
         @endif
         x-transition:enter="ease-out duration-300"
@@ -37,7 +37,7 @@
 
     <div class="w-full min-h-full transform flex items-end justify-center mx-auto {{ $align }} {{ $maxWidth }}"
         x-show="show"
-        @if(! $attributes->get('prevent-outside-close'))
+        @if(! $persistent)
             x-on:click.self="close"
         @endif
         x-transition:enter="ease-out duration-300"

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -24,9 +24,9 @@
             $blur => (bool) $blur
         ])
         x-show="show"
-        @if(! $persistent)
+        @unless($persistent)
             x-on:click="close"
-        @endif
+        @unless
         x-transition:enter="ease-out duration-300"
         x-transition:enter-start="opacity-0"
         x-transition:enter-end="opacity-100"

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -13,7 +13,8 @@ class Modal extends Component
         public ?string $spacing = null,
         public ?string $align = null,
         public string|bool|null $blur = null,
-        public bool $show = false
+        public bool $show = false,
+        public bool $persistent = false
     ) {
         $zIndex   ??= config('wireui.modal.zIndex');
         $maxWidth ??= config('wireui.modal.maxWidth');


### PR DESCRIPTION
This PR allows the control of modal close events on outside click
As discussed https://github.com/wireui/wireui/discussions/657, there's a use case to create a non-closable modal
I believe this would be useful

To create a non-closable modal, below describes how it can be done
``` html
<x-modal wire:model.defer="cardModal" align="center" prevent-outside-close="true">
    ...
</x-modal>
```