### PR TITLE
Removed border duplication from input when in focus.

### DIFF
--- a/src/resources/views/components/wrapper/element.blade.php
+++ b/src/resources/views/components/wrapper/element.blade.php
@@ -6,6 +6,7 @@
     ])->class([
         'bg-transparent block w-full border-0 text-gray-900 dark:text-gray-400',
         'p-0 outline-0 ring-0 sm:text-sm sm:leading-6',
+        'focus:ring-0 focus:border-0',
         'placeholder:text-gray-400 dark:placeholder:text-gray-300',
         'invalidated:text-negative-800 invalidated:dark:text-negative-600',
         'invalidated:placeholder-negative-400 invalidated:dark:placeholder-negative-600/70',


### PR DESCRIPTION
### Description
Removed border duplication from input when in focus.



### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have not added tests, the reason is: **..**
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have created a branch (PR from **main** branch will be closed)
- [ ] New and existing unit tests pass **locally** with my changes
- [x] The PR does not contain multiple unrelated changes

### Issue Reference
The PR was created to adjust the edge duplicity of the input component

### Screenshots
![Captura de tela de 2023-11-12 20-44-43](https://github.com/wireui/wireui/assets/44820260/3df78887-3858-4c45-a998-c97be8f3f137)

[//]: # (Thanks for contributing! 🙌)
