### PR TITLE
fix getting started URL in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ All contributions are welcome!
 MIT
 
 [TALL stack]: https://tallstack.dev
-[Get Started]: https://wireui.dev/docs/get-started
+[Get Started]: https://wireui.dev/getting-started
 [Documentation]: https://wireui.dev
 [@ph7jack]: https://twitter.com/ph7jack
 [Pedro Oliveira]: https://github.com/PH7-Jack


### PR DESCRIPTION


### Description
Getting Started URL was set to /docs/get-started which no longer exists and should be /getting-started

### Checklist
- [x ] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/CONTRIBUTING.md) guide
- [ x] I have added tests that prove my fix is effective or that my feature works
- [x ] I have not added tests, the reason is: Simple change in readme
- [x ] I have added the necessary documentation (if appropriate)
- [x ] I have created a branch (PR from **main** branch will be closed)
- [ x] New and existing unit tests pass **locally** with my changes
- [ x] The PR does not contain multiple unrelated changes

