### PR TITLE
added rows and cols attributes to the textarea

### DIFF
--- a/src/View/Components/Textarea.php
+++ b/src/View/Components/Textarea.php
@@ -16,8 +16,8 @@ class Textarea extends WireUiComponent
 
     protected array $props = [
         'shadowless' => false,
-        'rows' => 4,
-        'cols' => 'auto',
+        'rows'       => 4,
+        'cols'       => 'auto',
     ];
 
     protected function except(): array

--- a/src/View/Components/Textarea.php
+++ b/src/View/Components/Textarea.php
@@ -16,6 +16,8 @@ class Textarea extends WireUiComponent
 
     protected array $props = [
         'shadowless' => false,
+        'rows' => 4,
+        'cols' => 'auto',
     ];
 
     protected function except(): array

--- a/src/resources/views/components/textarea.blade.php
+++ b/src/resources/views/components/textarea.blade.php
@@ -14,14 +14,16 @@
                 'type' => 'text',
                 'autocomplete' => 'off',
                 'placeholder' => ' ',
-                'rows' => 4,
+                'rows' => $rows,
+                'cols' => $cols,
             ])
             ->except(['wire:key', 'x-data', 'class'])
             ->class([
-                'bg-transparent block w-full !border-0 text-gray-900 placeholder:text-gray-400',
+                'bg-transparent block !border-0 text-gray-900 placeholder:text-gray-400',
                 'pl-3 pr-2.5 py-2 !outline-0 !ring-0 sm:text-sm sm:leading-normal',
                 'invalidated:text-negative-800 invalidated:dark:text-negative-600',
-                'invalidated:placeholder-negative-400 invalidated:dark:placeholder-negative-600/70',
+                'invalidated:placeholder-negative-400 invalidated:dark:placeholder-negative-600/70'
+                .($cols === 'auto' ? ' w-full' : ''), // if the consumer has set cols, then we shouldn't force the textarea full width
             ]) }}
     >{{ $slot }}</textarea>
 </x-wrapper>

--- a/src/resources/views/components/textarea.blade.php
+++ b/src/resources/views/components/textarea.blade.php
@@ -22,8 +22,8 @@
                 'bg-transparent block !border-0 text-gray-900 placeholder:text-gray-400',
                 'pl-3 pr-2.5 py-2 !outline-0 !ring-0 sm:text-sm sm:leading-normal',
                 'invalidated:text-negative-800 invalidated:dark:text-negative-600',
-                'invalidated:placeholder-negative-400 invalidated:dark:placeholder-negative-600/70'
-                .($cols === 'auto' ? ' w-full' : ''), // if the consumer has set cols, then we shouldn't force the textarea full width
+                'invalidated:placeholder-negative-400 invalidated:dark:placeholder-negative-600/70',
+                'w-full' => $cols === 'auto'
             ]) }}
     >{{ $slot }}</textarea>
 </x-wrapper>

--- a/tests/Browser/Components/TextareaTest.php
+++ b/tests/Browser/Components/TextareaTest.php
@@ -8,21 +8,11 @@ use Tests\Browser\BrowserTestCase;
 
 class TextareaTest extends BrowserTestCase
 {
-    public function component(): Testable
+    public function rowAttributeComponent(): Testable
     {
         return Livewire::test(new class() extends Component
         {
             public $model = null;
-
-            public function validateTextarea()
-            {
-                $this->validate();
-            }
-
-            public function resetTextareaValidation()
-            {
-                $this->resetValidation();
-            }
 
             public function render(): string
             {
@@ -31,7 +21,24 @@ class TextareaTest extends BrowserTestCase
                     <h1>Textarea Livewire Test</h1>
 
                     // test it_should_see_the_rows_attribute
-                    <x-textarea rows="10" cols="auto" wire:model.live="errorless" />
+                    <x-textarea rows="10" wire:model.live="errorless" />
+                </div>
+                BLADE;
+            }
+        });
+    }
+
+    public function colAttributeComponent(): Testable
+    {
+        return Livewire::test(new class() extends Component
+        {
+            public $model = null;
+
+            public function render(): string
+            {
+                return <<<'BLADE'
+                <div>
+                    <h1>Textarea Livewire Test</h1>
 
                     // test it_should_see_the_cols_attribute
                     <x-textarea rows="10" cols="10" wire:model.live="errorless" />
@@ -43,22 +50,23 @@ class TextareaTest extends BrowserTestCase
 
     public function test_it_should_see_the_rows_attribute(): void
     {
-        $this->component()
+        $this->rowAttributeComponent()
             ->assertSeeHtml('rows="10"');
     }
 
     public function test_it_should_see_the_cols_attribute(): void
     {
-        $this->component()
+        $this->colAttributeComponent()
             ->assertSeeHtml('cols="10"');
     }
 
     public function test_cols_should_default_to_auto_attribute(): void
     {
-        $this->component()
+        // rowAttributeComponent doesn't have cols attribute set, thus it should be auto and w-full
+        $this->rowAttributeComponent()
             ->assertSeeHtml('cols="auto"');
 
-        $this->component()
+        $this->rowAttributeComponent()
             ->assertSeeHtml('w-full');
     }
 }

--- a/tests/Browser/Components/TextareaTest.php
+++ b/tests/Browser/Components/TextareaTest.php
@@ -11,7 +11,8 @@ class TextareaTest extends BrowserTestCase
 {
     public function browser(): Browser
     {
-        return Livewire::visit(new class () extends Component {
+        return Livewire::visit(new class() extends Component
+        {
             public $model = null;
 
             public function render(): string
@@ -32,7 +33,8 @@ class TextareaTest extends BrowserTestCase
 
     public function component(): Testable
     {
-        return Livewire::test(new class () extends Component {
+        return Livewire::test(new class() extends Component
+        {
             public $model = null;
 
             public function validateTextarea()
@@ -72,7 +74,6 @@ class TextareaTest extends BrowserTestCase
     {
         $this->component()
             ->assertSeeHtml('cols="10"');
-
     }
 
     public function test_cols_should_default_to_auto_attribute(): void

--- a/tests/Browser/Components/TextareaTest.php
+++ b/tests/Browser/Components/TextareaTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Browser\Components;
+
+use Laravel\Dusk\Browser;
+use Livewire\Features\SupportTesting\Testable;
+use Livewire\{Component, Livewire};
+use Tests\Browser\BrowserTestCase;
+
+class TextareaTest extends BrowserTestCase
+{
+    public function browser(): Browser
+    {
+        return Livewire::visit(new class () extends Component {
+            public $model = null;
+
+            public function render(): string
+            {
+                return <<<'BLADE'
+                <div>
+                    <h1>Textarea Browser Test</h1>
+
+                    // test it_should_set_model_value_to_livewire
+                    <x-textarea dusk="textarea" wire:model.live="model" label="Model Textarea" />
+
+                    <span dusk="model-value">{{ $model }}</span>
+                </div>
+                BLADE;
+            }
+        });
+    }
+
+    public function component(): Testable
+    {
+        return Livewire::test(new class () extends Component {
+            public $model = null;
+
+            public function validateTextarea()
+            {
+                $this->validate();
+            }
+
+            public function resetTextareaValidation()
+            {
+                $this->resetValidation();
+            }
+
+            public function render(): string
+            {
+                return <<<'BLADE'
+                <div>
+                    <h1>Textarea Livewire Test</h1>
+
+                    // test it_should_see_the_rows_attribute
+                    <x-textarea rows="10" cols="auto" wire:model.live="errorless" />
+
+                    // test it_should_see_the_cols_attribute
+                    <x-textarea rows="10" cols="10" wire:model.live="errorless" />
+                </div>
+                BLADE;
+            }
+        });
+    }
+
+    public function test_it_should_see_the_rows_attribute(): void
+    {
+        $this->component()
+            ->assertSeeHtml('rows="10"');
+    }
+
+    public function test_it_should_see_the_cols_attribute(): void
+    {
+        $this->component()
+            ->assertSeeHtml('cols="10"');
+
+    }
+
+    public function test_cols_should_default_to_auto_attribute(): void
+    {
+        $this->component()
+            ->assertSeeHtml('cols="auto"');
+
+        $this->component()
+            ->assertSeeHtml('w-full');
+    }
+}

--- a/tests/Browser/Components/TextareaTest.php
+++ b/tests/Browser/Components/TextareaTest.php
@@ -2,35 +2,12 @@
 
 namespace Tests\Browser\Components;
 
-use Laravel\Dusk\Browser;
 use Livewire\Features\SupportTesting\Testable;
 use Livewire\{Component, Livewire};
 use Tests\Browser\BrowserTestCase;
 
 class TextareaTest extends BrowserTestCase
 {
-    public function browser(): Browser
-    {
-        return Livewire::visit(new class() extends Component
-        {
-            public $model = null;
-
-            public function render(): string
-            {
-                return <<<'BLADE'
-                <div>
-                    <h1>Textarea Browser Test</h1>
-
-                    // test it_should_set_model_value_to_livewire
-                    <x-textarea dusk="textarea" wire:model.live="model" label="Model Textarea" />
-
-                    <span dusk="model-value">{{ $model }}</span>
-                </div>
-                BLADE;
-            }
-        });
-    }
-
     public function component(): Testable
     {
         return Livewire::test(new class() extends Component


### PR DESCRIPTION
### Description
Added rows and cols attributes to the Textarea livewire componenet

### Checklist
- [✔️] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/CONTRIBUTING.md) guide
- [✔️ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have not added tests, the reason is: **..**
- [ ] I have added the necessary documentation (if appropriate) - I haven't. Will need a new PR in the docs
- [✔️] I have created a branch (PR from **main** branch will be closed)
- [✔️] New and existing unit tests pass **locally** with my changes
- [ ✔️] The PR does not contain multiple unrelated changes

### Issue Reference
- Fixes https://github.com/wireui/wireui/issues/852
