### PR TITLE
Remove fixed width of select options

### DIFF
--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -179,7 +179,6 @@
 
     <x-wireui::parts.popover
         :margin="(bool) $label"
-        class="sm:max-w-xs"
     >
         <template x-if="asyncData.api || (config.searchable && options.length >= @toJs($minItemsForSearch))">
             <div class="px-2 my-2" wire:key="search.options.{{ $name }}">


### PR DESCRIPTION
### Description
The width of select options they are not the same of the select field size.

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have not added tests, the reason is: **..**
- [x] I have added the necessary documentation (if appropriate)
- [x] I have created a branch (PR from **main** branch will be closed)
- [x] New and existing unit tests pass **locally** with my changes
- [x] The PR does not contain multiple unrelated changes


### Screenshots
Before:
<img width="834" alt="image" src="https://github.com/wireui/wireui/assets/497169/01afab4a-2ea3-4b97-ba66-ae8c40dd362a">

After:
<img width="838" alt="image" src="https://github.com/wireui/wireui/assets/497169/842502ab-4c80-491e-b31c-e55bc0b7720a">

