### PR TITLE
Fix issue with standard to military time conversion

### DIFF
--- a/tests/TypeScript/utils/time.spec.ts
+++ b/tests/TypeScript/utils/time.spec.ts
@@ -48,7 +48,7 @@ describe('Testing The time helpers', () => {
       { time: '9:45 AM', expected: '09:45' },
       { time: '10:50 AM', expected: '10:50' },
       { time: '11:55 AM', expected: '11:55' },
-      { time: '0:00 PM', expected: '12:00' },
+      { time: '12:00 PM', expected: '12:00' },
       { time: '1:05 PM', expected: '13:05' },
       { time: '2:10 PM', expected: '14:10' },
       { time: '3:15 PM', expected: '15:15' },
@@ -59,7 +59,9 @@ describe('Testing The time helpers', () => {
       { time: '8:40 PM', expected: '20:40' },
       { time: '9:45 PM', expected: '21:45' },
       { time: '10:50 PM', expected: '22:50' },
-      { time: '11:55 PM', expected: '23:55' }
+      { time: '11:55 PM', expected: '23:55' },
+      { time: '12:12 AM', expected: '00:12' },
+      { time: '12:12 PM', expected: '12:12' }
     ]
 
     times.forEach(({ time, expected }) => {

--- a/ts/utils/time.ts
+++ b/ts/utils/time.ts
@@ -31,8 +31,12 @@ export const convertStandardTimeToMilitary = (time: string): string => {
 
   let standardHour = Number(hour)
 
-  if (time.includes('PM')) {
+  if (time.includes('PM') && standardHour < 12) {
     standardHour += 12
+  }
+
+  if (time.includes('AM') && standardHour === 12) {
+    standardHour = 0
   }
 
   const militaryHour = standardHour.toString().padStart(2, '0')


### PR DESCRIPTION
### Description
Update the standard to military time conversion function to correctly handle times starting with 12.

Previously, the function incorrectly converted times starting with 12. For example, it converted 12:22 PM to 24:22, and 12:22 AM to 12:22, which does not accurately represent the corresponding military time. It was fixed to convert respectively to 12:22 and 00:22.

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have created a branch (PR from **main** branch will be closed)
- [x] New and existing unit tests pass **locally** with my changes
- [x] The PR does not contain multiple unrelated changes

### Issue Reference
- Fixes #705 

Note: This issue also exists in the version using Livewire 2, such as 1.17.x. Please generate a new tag of this version containing this fix as well or provide instructions on which branch should be the source to fix this version.