### PR TITLE
Fix ctype_lower() warning message

### DIFF
--- a/src/Actions/Dialog.php
+++ b/src/Actions/Dialog.php
@@ -31,7 +31,7 @@ class Dialog
 
     public static function makeEventName(?string $dialogId = null): string
     {
-        $id = Str::kebab($dialogId);
+        $id = Str::kebab($dialogId ?? '');
 
         return ! empty($id) ? "dialog:{$id}" : 'dialog';
     }


### PR DESCRIPTION
### Description

When using Debugbar, a `ctype_lower(): Argument of type null will be interpreted as string in the future...` warning message is being logged.

![ctype_lower-warning](https://github.com/user-attachments/assets/803537c1-5704-4267-b33f-fada91553690)


### Checklist
- [ ] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have not added tests, the reason is that the fix is simple.
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have created a branch (PR from **main** branch will be closed)
- [ ] New and existing unit tests pass **locally** with my changes
- [ ] The PR does not contain multiple unrelated changes

[//]: # (Thanks for contributing! 🙌)
