### PR TITLE
fix(lang): fix french translations

### DIFF
--- a/src/lang/fr/messages.php
+++ b/src/lang/fr/messages.php
@@ -7,8 +7,7 @@ return [
     'search_here' => 'Cherchez ici',
     'date_picker' => [
         'months' => ['Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin', 'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre'],
-        'months' => ['Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin', 'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre'],
-        'days' => "['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam']",
+        'days' => ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'],
         'tomorrow' => 'Demain',
         'today' => 'Aujourd\'hui',
         'yesterday' => 'Hier',


### PR DESCRIPTION
### Description
This corrects the `datetime-picker` user interface when using the `fr` locale.
It also corrects the selection behavior when the same component/page contains a `datetime-picker` (when using the `fr` locale).

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have not added tests, the reason is it's a i18n issue
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have created a branch (PR from **main** branch will be closed)
- [ ] New and existing unit tests pass **locally** with my changes
- [x] The PR does not contain multiple unrelated changes

[//]: # (Thanks for contributing! 🙌)
