### PR TITLE
Update picker.blade.php

### DIFF
--- a/src/Components/DatetimePicker/views/picker.blade.php
+++ b/src/Components/DatetimePicker/views/picker.blade.php
@@ -99,7 +99,6 @@
     <x-wireui-wrapper::element
         readonly
         autocomplete="off"
-        :attributes="$input"
         class="cursor-pointer"
         x-bind:value="display"
         x-show="selectedDates.length === 0"


### PR DESCRIPTION
Fix datetime picker

### Description
Removed  :attributes="$input" from x-wireui-wrapper::element, is not effective and overrides the readonly attribute on the component

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/contributing.md) guide
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have created a branch (PR from **main** branch will be closed)
- [x] New and existing unit tests pass **locally** with my changes
- [x] The PR does not contain multiple unrelated changes

### Issue Reference
- Fixes #985



[//]: # (Thanks for contributing! 🙌)
