### PR TITLE
update x-model binding to support color name as value

### DIFF
--- a/src/Components/ColorPicker/views/picker.blade.php
+++ b/src/Components/ColorPicker/views/picker.blade.php
@@ -25,7 +25,7 @@
     <x-wireui-wrapper::element
         x-ref="input"
         :attributes="$input"
-        :x-model="$colorNameAsValue ? 'selected.name' : 'selected.value'"
+        x-model.fill="$wire.colorNameAsValue ? selected.name : selected.value"
         x-on:blur="onBlur($event.target.value)"
         x-on:input="setColor($event.target.value)"
     />

--- a/src/Components/ColorPicker/views/picker.blade.php
+++ b/src/Components/ColorPicker/views/picker.blade.php
@@ -25,7 +25,7 @@
     <x-wireui-wrapper::element
         x-ref="input"
         :attributes="$input"
-        x-model.fill="selected.value"
+        :x-model="$colorNameAsValue ? 'selected.name' : 'selected.value'"
         x-on:blur="onBlur($event.target.value)"
         x-on:input="setColor($event.target.value)"
     />


### PR DESCRIPTION
### Description
This pull request includes a change to the `src/Components/ColorPicker/views/picker.blade.php` file to fix the issue when using the `colorNameAsValue `attribute

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/contributing.md) guide
- [x] I have created a branch (PR from **main** branch will be closed)
- [x] New and existing unit tests pass **locally** with my changes
- [x] The PR does not contain multiple unrelated changes

### Issue Reference
- Fixes #995