### PR TITLE
Support both direction RTL and LTR

### DIFF
--- a/src/Components/Alert/WireUi/Padding.php
+++ b/src/Components/Alert/WireUi/Padding.php
@@ -15,10 +15,10 @@ class Padding extends ComponentPack
     public function all(): array
     {
         return [
-            Packs\Padding::NONE => 'ml-2',
-            Packs\Padding::SMALL => 'pl-1 mt-1 ml-3',
-            Packs\Padding::MEDIUM => 'pl-1 mt-2 ml-5',
-            Packs\Padding::LARGE => 'pl-1 mt-3 ml-7',
+            Packs\Padding::NONE => 'ms-2 me-2',
+            Packs\Padding::SMALL => 'ps-1 pe-1 mt-1 ms-3 me-3',
+            Packs\Padding::MEDIUM => 'ps-1 pe-1 mt-2 ms-5 me-5',
+            Packs\Padding::LARGE => 'ps-1 pe-1 mt-3 ms-7 me-7',
         ];
     }
 }

--- a/src/Components/Alert/views/index.blade.php
+++ b/src/Components/Alert/views/index.blade.php
@@ -21,7 +21,7 @@
                         :name="$icon"
                         @class([
                             data_get($colorClasses, 'iconColor', ''),
-                            'w-5 h-5 mr-3 shrink-0',
+                            'w-5 h-5 ms-3 me-3 shrink-0',
                         ])
                     />
                 @endif

--- a/src/Components/ColorPicker/views/picker.blade.php
+++ b/src/Components/ColorPicker/views/picker.blade.php
@@ -57,7 +57,7 @@
         <x-dynamic-component
             :component="WireUi::component('popover')"
             :margin="(bool) $label"
-            root-class="justify-end sm:w-full"
+            root-class="ltr:justify-end rtl:justify-start sm:w-full"
             @class([
                 'max-h-64 select-none overflow-hidden',
                 'sm:w-auto sm:max-w-[19rem]',

--- a/src/Components/DatetimePicker/views/picker.blade.php
+++ b/src/Components/DatetimePicker/views/picker.blade.php
@@ -110,7 +110,7 @@
             @if ($clearable)
                 <x-dynamic-component
                     :component="WireUi::component('icon')"
-                    class="w-4 h-4 mr-2 text-gray-400 transition-colors duration-150 ease-in-out cursor-pointer hover:text-negative-500 invalidated:text-negative-600"
+                    class="w-4 h-4 text-gray-400 transition-colors duration-150 ease-in-out cursor-pointer ms-2 me-2 hover:text-negative-500 invalidated:text-negative-600"
                     name="x-mark"
                     x-show="entangleable.isNotEmpty()"
                     x-on:click.stop.prevent="clear"

--- a/src/Components/Dialog/views/index.blade.php
+++ b/src/Components/Dialog/views/index.blade.php
@@ -47,13 +47,13 @@
                 'sm:p-5 sm:pt-7': style === 'center',
                 'sm:p-0 sm:pt-1': style === 'inline',
             }">
-            <div class="absolute top-0 left-0 transition-all duration-150 ease-linear rounded-full bg-secondary-300 dark:bg-secondary-600"
+            <div class="absolute top-0 transition-all duration-150 ease-linear rounded-full ltr:left-0 rtl:right-0 bg-secondary-300 dark:bg-secondary-600"
                 style="height: 2px; width: 100%;"
                 x-ref="progressbar"
                 x-show="dialog && dialog.progressbar && dialog.timeout">
             </div>
 
-            <div x-show="dialog && dialog.closeButton" class="absolute right-2 -top-2">
+            <div x-show="dialog && dialog.closeButton" class="absolute ltr:right-2 rtl:left-2 -top-2">
                 <button class="{{ $dialog }}-button-close focus:outline-none p-1 focus:ring-2 focus:ring-secondary-200 rounded-full text-secondary-300"
                     x-on:click="close"
                     type="button">
@@ -75,13 +75,13 @@
 
                 <div class="w-full mt-4" :class="{ 'sm:mt-5': style === 'center' }">
                     <h3 class="text-lg font-medium leading-6 text-center text-secondary-900 dark:text-secondary-400"
-                        :class="{ 'sm:text-left': style === 'inline' }"
+                        :class="{ 'ltr:sm:text-left rtl:sm:text-right': style === 'inline' }"
                         @unless($title) x-ref="title" @endunless>
                         {{ $title }}
                     </h3>
 
                     <p class="mt-2 text-sm text-center text-secondary-500"
-                        :class="{ 'sm:text-left': style === 'inline' }"
+                        :class="{ 'ltr:sm:text-left rtl:sm:text-right': style === 'inline' }"
                         @unless($description) x-ref="description" @endunless>
                         {{ $description }}
                     </p>
@@ -93,7 +93,7 @@
             <div class="grid grid-cols-1 gap-y-2 sm:gap-x-3 rounded-b-xl"
                 :class="{
                     'sm:grid-cols-2 sm:gap-y-0': style === 'center',
-                    'sm:p-4 sm:bg-secondary-100 sm:dark:bg-secondary-800 sm:grid-cols-none sm:flex sm:justify-end': style === 'inline',
+                    'sm:p-4 sm:bg-secondary-100 sm:dark:bg-secondary-800 sm:grid-cols-none sm:flex ltr:sm:justify-end rtl:sm:justify-start ': style === 'inline',
                 }"
                 x-show="dialog && (dialog.accept || dialog.reject)">
                 <div x-show="dialog && dialog.accept" class="sm:order-last" x-ref="accept"></div>

--- a/src/Components/Dropdown/views/base.blade.php
+++ b/src/Components/Dropdown/views/base.blade.php
@@ -3,7 +3,7 @@
     x-props="{
         position: '{{ $position }}',
     }"
-    class="relative inline-block text-left"
+    class="relative inline-block ltr:text-left rtl:text-right"
     x-on:click.outside="positionable.close()"
     x-on:keydown.escape.window="positionable.close()"
     {{ $attributes->only('wire:key') }}

--- a/src/Components/Dropdown/views/header.blade.php
+++ b/src/Components/Dropdown/views/header.blade.php
@@ -2,7 +2,7 @@
     'border-t border-secondary-200 dark:border-secondary-600' => $separator,
 ])>
     <h6 {{ $attributes->class([
-        'block pl-2 pt-2 pb-1 text-xs text-secondary-600 sticky top-0 bg-white',
+        'block ps-2 pe-2 pt-2 pb-1 text-xs text-secondary-600 sticky top-0 bg-white',
         'dark:bg-secondary-800 dark:text-secondary-400',
     ]) }}>
         {{ $label }}

--- a/src/Components/Dropdown/views/item.blade.php
+++ b/src/Components/Dropdown/views/item.blade.php
@@ -11,7 +11,7 @@
         <x-dynamic-component
             :component="WireUi::component('icon')"
             :name="$icon"
-            class="w-5 h-5 mr-2"
+            class="w-5 h-5 ms-2 me-2"
         />
     @endif
 

--- a/src/Components/Notifications/views/index.blade.php
+++ b/src/Components/Notifications/views/index.blade.php
@@ -1,5 +1,5 @@
 <div @class([
-        'fixed inset-0 flex items-end justify-center px-4 py-6 pointer-events-none sm:p-5 sm:pt-4',
+        'fixed inset-0 flex ltr:items-end rtl:items-start justify-center px-4 py-6 pointer-events-none sm:p-5 sm:pt-4',
         $positionClasses,
         $zIndex,
     ])
@@ -17,18 +17,18 @@
                  x-transition:enter-end="translate-y-0 opacity-100 sm:translate-x-0"
                  x-on:mouseenter="pauseNotification(notification)"
                  x-on:mouseleave="resumeNotification(notification)">
-                <div class="absolute top-0 left-0 transition-all duration-150 ease-linear rounded-full bg-secondary-300 dark:bg-secondary-600"
+                <div class="absolute top-0 transition-all duration-150 ease-linear rounded-full ltr:left-0 rtl:right-0 bg-secondary-300 dark:bg-secondary-600"
                      style="height: 2px; width: 100%;"
                      :id="`timeout.bar.${notification.id}`"
                      x-show="Boolean(notification.timer) && notification.progressbar !== false">
                 </div>
                 <div :class="{
-                        'pl-4': Boolean(notification.dense),
+                        'ps-4 pe-4': Boolean(notification.dense),
                         'p-4': !Boolean(notification.rightButtons),
                         'w-0 flex-1 flex items-center p-4': Boolean(notification.rightButtons),
                     }">
                     <div :class="{
-                        'flex items-start': !Boolean(notification.rightButtons),
+                        'flex ltr:items-start rtl:items-end': !Boolean(notification.rightButtons),
                         'w-full flex': Boolean(notification.rightButtons),
                     }">
                         <!-- notification icon|img -->
@@ -48,7 +48,7 @@
                         </template>
 
                         <div class="w-0 flex-1 pt-0.5" :class="{
-                                'ml-3': Boolean(notification.icon || notification.img)
+                                'ms-3 me-3': Boolean(notification.icon || notification.img)
                             }">
                             <p class="text-sm font-medium text-secondary-900 dark:text-secondary-400"
                                x-show="notification.title"
@@ -87,7 +87,7 @@
                             </template>
                         </div>
 
-                        <div class="flex ml-4 shrink-0">
+                        <div class="flex ms-4 me-4 shrink-0">
                             <!-- accept button -->
                             <button class="mr-4 text-sm font-medium rounded-md shrink-0 focus:outline-none"
                                     :class="{

--- a/src/Components/Popover/views/index.blade.php
+++ b/src/Components/Popover/views/index.blade.php
@@ -11,7 +11,7 @@
     @class([
         'fixed inset-0 z-20 flex sm:w-full sm:justify-end items-end sm:z-10 sm:absolute sm:inset-auto',
         'pointer-events-none transition-all ease-linear duration-150',
-        'sm:top-0 sm:right-0',
+        'sm:top-0 ltr:sm:right-0 rtl:sm:left-0',
         $rootClass,
     ])
 >

--- a/src/Components/Select/views/base.blade.php
+++ b/src/Components/Select/views/base.blade.php
@@ -95,7 +95,7 @@
                 <div wire:ignore class="flex items-center gap-1 flex-nowrap">
                     <template x-for="(option, index) in selectedOptions" :key="`selected.${index}.${option.value}.${option.label}`">
                         <span class="
-                            inline-flex items-center py-0.5 pl-2 pr-0.5 rounded-full text-xs font-medium
+                            inline-flex items-center py-0.5 ltr:pl-2 rtl:pr-2 ltr:pr-0.5 rtl:pl-0.5 rounded-full text-xs font-medium
                             border border-secondary-200 shadow-sm bg-secondary-100 text-secondary-700
                             dark:bg-secondary-700 dark:text-secondary-400 dark:border-none
                         ">
@@ -121,7 +121,7 @@
         </div>
     </button>
 
-    <x-slot name="append" class="flex items-center pr-2.5 gap-x-1">
+    <x-slot name="append" class="flex items-center ltr:pr-2.5 rtl:pl-2.5 gap-x-1">
         @if ($clearable && !$readonly && !$disabled)
             <button
                 x-show="isNotEmpty()"
@@ -216,7 +216,7 @@
 
                 @unless ($hideEmptyMessage)
                     <div
-                        class="px-3 py-12 text-center cursor-pointer sm:py-2 sm:px-3 sm:text-left text-secondary-500"
+                        class="px-3 py-12 text-center cursor-pointer sm:py-2 sm:px-3 ltr:sm:text-left rtl:sm:text-right text-secondary-500"
                         x-show="displayOptions.length === 0"
                         x-on:click="search ? resetSearch() : positionable.close()"
                     >

--- a/src/Components/Switcher/WireUi/Toggle/Size.php
+++ b/src/Components/Switcher/WireUi/Toggle/Size.php
@@ -25,15 +25,15 @@ class Size extends ComponentPack
             ],
             Packs\Size::MD => [
                 'background' => 'h-5 w-9',
-                'circle' => 'checked:translate-x-3.5 left-0.5 w-3.5 h-3.5',
+                'circle' => 'checked:translate-x-3.5 rtl:right-0.5 ltr:left-0.5 w-3.5 h-3.5',
             ],
             Packs\Size::LG => [
                 'background' => 'h-6 w-10',
-                'circle' => 'checked:translate-x-4 left-0.5 w-4 h-4',
+                'circle' => 'checked:translate-x-4 rtl:right-0.5 ltr:left-0.5 w-4 h-4',
             ],
             Packs\Size::XL => [
                 'background' => 'h-7 w-12',
-                'circle' => 'checked:translate-x-5.5 left-0.5 w-4 h-4',
+                'circle' => 'checked:translate-x-5.5 rtl:right-0.5 ltr:left-0.5 w-4 h-4',
             ],
         ];
     }

--- a/src/Components/TextField/views/textarea.blade.php
+++ b/src/Components/TextField/views/textarea.blade.php
@@ -20,7 +20,7 @@
             ])
             ->class([
                 'bg-transparent block !border-0 text-gray-900 dark:text-gray-400',
-                'pl-3 pr-2.5 py-2 !outline-0 !ring-0 sm:text-sm sm:leading-normal',
+                'ltr:pl-3 rtl:pr-3 ltr:pr-2.5 rtl:pl-2.5 py-2 !outline-0 !ring-0 sm:text-sm sm:leading-normal',
                 'placeholder:text-gray-400 dark:placeholder:text-gray-300',
                 'invalidated:text-negative-800 invalidated:dark:text-negative-600',
                 'invalidated:placeholder-negative-400 invalidated:dark:placeholder-negative-600/70',

--- a/src/Components/TimePicker/views/selector.blade.php
+++ b/src/Components/TimePicker/views/selector.blade.php
@@ -25,7 +25,7 @@
     />
 
     <div @class([
-        'absolute bg-primary-50 dark:bg-primary-200/10 left-0 h-10 w-full transform transition-opacity',
+        'absolute bg-primary-50 dark:bg-primary-200/10 ltr:left-0 rtl:right-0 h-10 w-full transform transition-opacity',
     ])></div>
 
     <ul wire:ignore class="w-full" x-ref="hours"></ul>

--- a/src/Components/Wrapper/views/text-field.blade.php
+++ b/src/Components/Wrapper/views/text-field.blade.php
@@ -63,8 +63,8 @@
                 '!bg-gray-100' => $disabled && !$invalidated,
 
                 $padding =>  $padding,
-                'pl-3'   => !$padding && !isset($prepend),
-                'pr-3'   => !$padding && !isset($append),
+                'ps-3 pe-3'   => !$padding && !isset($prepend),
+                'ps-3 pe-3'   => !$padding && !isset($append),
                 'py-2'   => !$padding && !isset($prepend) && !isset($append),
                 'h-10'   => isset($prepend) || isset($append),
 
@@ -98,7 +98,7 @@
             <div name="form.wrapper.container.prepend"
                 {{ $prepend->attributes->class([
                     'group/prepend wrapper-prepend-slot',
-                    'flex h-full py-0.5 pl-0.5',
+                    'flex h-full py-0.5 ps-0.5 pe-0.5',
                 ]) }}
             >
                 {{ $prepend }}
@@ -138,7 +138,7 @@
                 name="form.wrapper.container.append"
                 {{ $append->attributes->class([
                     'group/append shrink-0 wrapper-append-slot',
-                    'flex h-full py-0.5 pr-0.5',
+                    'flex h-full py-0.5 ps-0.5 pe-0.5',
                 ]) }}
             >
                 {{ $append }}


### PR DESCRIPTION
Description
This update adds support for both RTL (right-to-left) and LTR (left-to-right) text directions across all WireUI components. The changes ensure that the UI aligns properly based on the page's direction setting, enhancing usability for RTL languages like Arabic and Hebrew.

Changes Made
Updated CSS to handle both RTL and LTR directions for components like forms, modals, and dropdowns.
Added conditional classes and styles to switch direction based on the dir attribute.
Adjusted JavaScript where necessary to ensure correct alignment and responsiveness in RTL.
Checklist
 I have read the contributing guidelines.
 I have added the necessary documentation for RTL/LTR configuration.
 Unit tests pass with these changes.