### PR TITLE
Allow render of option with html tags when using multiselect.

### DIFF
--- a/src/Components/Select/views/base.blade.php
+++ b/src/Components/Select/views/base.blade.php
@@ -99,7 +99,7 @@
                             border border-secondary-200 shadow-sm bg-secondary-100 text-secondary-700
                             dark:bg-secondary-700 dark:text-secondary-400 dark:border-none
                         ">
-                            <span style="max-width: 5rem" class="truncate select-none" x-text="option.label"></span>
+                            <span style="max-width: 5rem" class="truncate select-none" x-html="option.label"></span>
 
                             <button
                                 class="flex items-center justify-center w-4 h-4 shrink-0 text-secondary-400 hover:text-secondary-500"


### PR DESCRIPTION
### Description
When the option label contains an HTML tags in multiselect mode, the selected options are not properly rendered.

### Checklist
- [X] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/contributing.md) guide
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have not added tests, the reason is: The fix is simple.
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have created a branch (PR from **main** branch will be closed)
- [ ] New and existing unit tests pass **locally** with my changes
- [ ] The PR does not contain multiple unrelated changes
