### PR TITLE
Update Base.php

### DIFF
--- a/src/Components/Select/Base.php
+++ b/src/Components/Select/Base.php
@@ -65,7 +65,7 @@ class Base extends WireUiComponent
 
     public function getOptionLabel(mixed $option): string
     {
-        return data_get($option, $this->optionLabel);
+        return (string) data_get($option, $this->optionLabel);
     }
 
     public function optionsToArray(): array


### PR DESCRIPTION
### Description
Strictly return the string even if label is null

### Issue Reference
- Fix WireUi\Components\Select\Base::getOptionLabel(): Return value must be of type string, null returned

[//]: # (Thanks for contributing! 🙌)
