### PR TITLE
Fix time-picker to use string from translations

### DIFF
--- a/src/Components/DatetimePicker/views/picker.blade.php
+++ b/src/Components/DatetimePicker/views/picker.blade.php
@@ -233,7 +233,7 @@
 
                 <div x-show="tab === 'time-picker'" class="flex items-center justify-between">
                     <h3 class="font-medium text-slate-600">
-                        Time Selection
+                        {{ trans('wireui::messages.select_time') }}
                     </h3>
 
                     <x-dynamic-component


### PR DESCRIPTION
### Description
Fix for the time-picker to use 'Select Time' string from translations so it displays in the correct language.

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/contributing.md) guide
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have not added tests, the reason is: **simple fix**
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have created a branch (PR from **main** branch will be closed)
- [ ] New and existing unit tests pass **locally** with my changes
- [x] The PR does not contain multiple unrelated changes

[//]: # (Thanks for contributing! 🙌)
