### PR TITLE
Allow Livewire actions on form fields

### DIFF
--- a/src/Traits/Components/InteractsWithWrapper.php
+++ b/src/Traits/Components/InteractsWithWrapper.php
@@ -37,7 +37,7 @@ trait InteractsWithWrapper
             'disabled',
             'readonly',
             'required',
-            'wire:model',
+            'wire:',
             'placeholder',
             'autocomplete',
         ];


### PR DESCRIPTION
This adds support for [Livewire actions](https://livewire.laravel.com/docs/actions) like wire:keydown.enter

### Description
Please explain the changes you made here. 
PR without a description will be closed. 

### Checklist
- [X] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/contributing.md) guide
- [X] I have not added tests, the reason is: wire:* attributes will only show up if the user specifies it
- [X] I have created a branch (PR from **main** branch will be closed)
- [X] New and existing unit tests pass **locally** with my changes
- [X] The PR does not contain multiple unrelated changes

### Issue Reference
- Fixes #988 

### Screenshots
If applicable, add screenshots or video URL to help explain your changes.

[//]: # (Thanks for contributing! 🙌)
