### PR TITLE
Update Bosnian (bs) translations

### DIFF
--- a/src/lang/bs/messages.php
+++ b/src/lang/bs/messages.php
@@ -2,7 +2,7 @@
 
 return [
     'select_time' => 'Izaberi vrijeme',
-    'empty_options' => 'Očisti izbor',
+    'empty_options' => 'Nema rezultata',
     'loading' => 'Učitavanje...',
     'search_here' => 'Potraži ovdje',
     'date_picker' => [

--- a/src/lang/bs/messages.php
+++ b/src/lang/bs/messages.php
@@ -11,8 +11,15 @@ return [
         'tomorrow' => 'Sutra',
         'today' => 'Danas',
         'yesterday' => 'Juče',
+        'clear' => 'Očisti',
+        'close' => 'Zatvori',
+        'apply' => 'Primeni',
+        'cancel' => 'Otkaži',
     ],
     'errors' => [
-        'title' => 'Postoje {errors} greške u unosu',
+        'title' => 'Došlo je do greške u unosu|Došlo je do {errors} grešaka u unosu',
+    ],
+    'labels' => [
+        'remove' => 'Ukloni',
     ],
 ];


### PR DESCRIPTION
### Description

This PR fixes two things:
- it fixes wrong translation of "empty_options" key. The old translation used the verb to empty the selection instead of reffering to empty state when there are no options. 
- it adds some missing translations

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/wireui/wireui/blob/main/contributing.md) guide
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have not added tests, the reason is: **not needed**
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have created a branch (PR from **main** branch will be closed)
- [x] New and existing unit tests pass **locally** with my changes
- [x] The PR does not contain multiple unrelated changes

### Issue Reference
- I did not create an issue since this updates only the translations

[//]: # (Thanks for contributing! 🙌)
